### PR TITLE
fix: correct macOS naming for OS detection

### DIFF
--- a/src/lib/target.ts
+++ b/src/lib/target.ts
@@ -160,7 +160,7 @@ export const detectTargetFromRequest = async (
       target: Target.linuxRpm,
     }
   }
-  if (os.name === 'Mac OS') {
+  if (os.name === 'macOS') {
     if (cpu.architecture === 'arm64' || cpu.architecture === 'arm') {
       return {
         os: OS.macos,


### PR DESCRIPTION
Fix incorrect OS detection

<img width="721" height="572" alt="image" src="https://github.com/user-attachments/assets/e8f5ecb2-ffa2-43b8-8348-64560906d0e9" />


```
# UAParser.js Changelog

## Migrating from v1 to v2

### What's Breaking:

- **Licensing Changes:**
  - UAParser.js is now licensed under AGPLv3 for open-source use, with PRO Licenses available for commercial/proprietary use

- **Browser Detection on Mobile Devices:**
    - `"Chrome"` => `"Mobile Chrome"`
    - `"Firefox"` => `"Mobile Firefox"`

- **OS Detection:**
    - `"Mac OS"` => `"macOS"`                            <-
    - `"Chromium OS"` => `"Chrome OS"`
...
```
See https://github.com/faisalman/ua-parser-js/blob/a4478735f6b1fafb0d94d0606653ec36681cba04/CHANGELOG.md#L15