### PR TITLE
fix: default macOS download to arm when arch unknown

### DIFF
--- a/src/lib/target.ts
+++ b/src/lib/target.ts
@@ -161,17 +161,20 @@ export const detectTargetFromRequest = async (
     }
   }
   if (os.name === 'macOS') {
-    if (cpu.architecture === 'arm64' || cpu.architecture === 'arm') {
+    // UAParser relies on high-entropy Client Hints for Mac CPU architecture.
+    // Serve Intel when the hint is explicit; otherwise default to Apple silicon.
+    // Learn more: https://github.com/faisalman/ua-parser-js/blob/18d39b53dd803710cb8e76856d18c1dcf7533d11/src/main/ua-parser.js#L122
+    if (cpu.architecture === 'amd64') {
       return {
         os: OS.macos,
-        spec: PlatformSpec.ARM,
-        target: Target.macosArm,
+        spec: PlatformSpec.X64Setup,
+        target: Target.macos,
       }
     }
     return {
       os: OS.macos,
-      spec: PlatformSpec.X64Setup,
-      target: Target.macos,
+      spec: PlatformSpec.ARM,
+      target: Target.macosArm,
     }
   }
   if (os.name === 'Windows') {


### PR DESCRIPTION
Fix https://github.com/poooi/poi/issues/2647

## Summary
- default macOS server-side target detection to Apple silicon when CPU architecture is unavailable
- still return the Intel macOS target when UAParser explicitly reports amd64
- document why server-side Mac architecture detection is unreliable with UAParser Client Hints

## Acknowledgements
- Thanks to @nekomeowww for helping debug the UAParser.js behavior around Client Hints and CPU architecture detection.

## Test
- pnpm exec eslint src/lib/target.ts