### PR TITLE
Add TanStack Worker shell

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -2,3 +2,9 @@
 # https://opennext.js.org/cloudflare/caching#static-assets-caching
 /_next/static/*
   Cache-Control: public,max-age=31536000,immutable
+
+/assets/*
+  Cache-Control: public,max-age=31536000,immutable
+
+/favicon.ico
+  Cache-Control: public,max-age=3600

--- a/specs-tanstack/scaffold.spec.ts
+++ b/specs-tanstack/scaffold.spec.ts
@@ -58,10 +58,12 @@ test('serves hashed Vite assets with immutable cache headers', async ({
 test('reserves monitoring route without locale/page headers', async ({
   request,
 }) => {
-  const response = await request.get('/api/monitoring')
+  for (const path of ['/api/monitoring', '/api/monitoring/']) {
+    const response = await request.get(path)
 
-  expect(response.status()).toBe(405)
-  expect(response.headers().allow).toBe('POST')
-  expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
-  expect(response.headers()['accept-ch']).toBeUndefined()
+    expect(response.status()).toBe(405)
+    expect(response.headers().allow).toBe('POST')
+    expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
+    expect(response.headers()['accept-ch']).toBeUndefined()
+  }
 })

--- a/specs-tanstack/scaffold.spec.ts
+++ b/specs-tanstack/scaffold.spec.ts
@@ -1,10 +1,67 @@
 import { expect, test } from '@playwright/test'
 
 test('renders the isolated TanStack preview route', async ({ page }) => {
-  await page.goto('/')
+  const response = await page.goto('/')
 
   await expect(
     page.getByRole('heading', { name: 'poi TanStack preview' }),
   ).toBeVisible()
   await expect(page.getByText('proves the scaffold builds')).toBeVisible()
+  expect(response).not.toBeNull()
+  const headers = response!.headers()
+  expect(headers['x-poi-codename']).toBe('Shiratsuyu')
+  expect(headers['x-poi-greetings']).toBe('poi?')
+  expect(headers['accept-ch']).toContain('Sec-CH-UA-Platform')
+  expect(headers['critical-ch']).toContain('Sec-CH-UA-Platform')
+  expect(headers.vary).toContain('Sec-CH-UA-Platform')
+  expect(headers['cache-control']).toBe('no-store')
+})
+
+test('marks HEAD page responses as no-store', async ({ request }) => {
+  const response = await request.head('/')
+
+  expect(response.status()).toBe(200)
+  expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
+  expect(response.headers()['cache-control']).toBe('no-store')
+})
+
+test('serves static assets before SSR with cache headers', async ({
+  request,
+}) => {
+  const response = await request.get('/favicon.ico')
+
+  expect(response.status()).toBe(200)
+  expect(response.headers()['x-poi-codename']).toBeUndefined()
+  expect(response.headers()['accept-ch']).toBeUndefined()
+  expect(response.headers()['cache-control']).toContain('public')
+})
+
+test('serves hashed Vite assets with immutable cache headers', async ({
+  page,
+  request,
+}) => {
+  await page.goto('/')
+  const scriptSrc = await page
+    .locator('script[src^="/assets/"]')
+    .first()
+    .getAttribute('src')
+
+  expect(scriptSrc).toBeTruthy()
+  const response = await request.get(scriptSrc!)
+
+  expect(response.status()).toBe(200)
+  expect(response.headers()['cache-control']).toBe(
+    'public,max-age=31536000,immutable',
+  )
+})
+
+test('reserves monitoring route without locale/page headers', async ({
+  request,
+}) => {
+  const response = await request.get('/api/monitoring')
+
+  expect(response.status()).toBe(405)
+  expect(response.headers().allow).toBe('POST')
+  expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
+  expect(response.headers()['accept-ch']).toBeUndefined()
 })

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,6 +8,21 @@ interface WorkerEnv {
   ASSETS?: AssetsBinding
 }
 
+interface ExecutionContextLike {
+  waitUntil(promise: Promise<unknown>): void
+  passThroughOnException?(): void
+}
+
+type StartHandlerWithContext = (
+  request: Request,
+  options: {
+    context: {
+      ctx: ExecutionContextLike
+      env: WorkerEnv
+    }
+  },
+) => Promise<Response>
+
 const clientHintValues =
   'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile'
 
@@ -118,17 +133,26 @@ const handleAsset = async (request: Request, env: WorkerEnv) => {
   return withAssetHeaders(response, request)
 }
 
+const isMonitoringPath = (pathname: string) => {
+  return pathname === '/api/monitoring' || pathname === '/api/monitoring/'
+}
+
 const worker = {
-  async fetch(request: Request, env: WorkerEnv) {
+  async fetch(request: Request, env: WorkerEnv, ctx: ExecutionContextLike) {
     const { pathname } = new URL(request.url)
 
     let response: Response | undefined
-    if (pathname === '/api/monitoring') {
+    if (isMonitoringPath(pathname)) {
       response = handleMonitoringStub(request)
     }
 
     response ??= await handleAsset(request, env)
-    response ??= await startHandler.fetch(request)
+    response ??= await (startHandler.fetch as StartHandlerWithContext)(
+      request,
+      {
+        context: { env, ctx },
+      },
+    )
 
     return withGlobalHeaders(response, request)
   },

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,137 @@
+import startHandler from '@tanstack/react-start/server-entry'
+
+interface AssetsBinding {
+  fetch(request: Request): Promise<Response>
+}
+
+interface WorkerEnv {
+  ASSETS?: AssetsBinding
+}
+
+const clientHintValues =
+  'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile'
+
+const buildDate = process.env.BUILD_DATE ?? 'development'
+const commitHash = process.env.COMMIT_HASH ?? 'development'
+
+const isFileRequest = (pathname: string) => {
+  return pathname.includes('.')
+}
+
+const isHashedViteAsset = (pathname: string) => {
+  return pathname.startsWith('/assets/')
+}
+
+const isPageRequest = (request: Request) => {
+  const { pathname } = new URL(request.url)
+  return (
+    (request.method === 'GET' || request.method === 'HEAD') &&
+    !pathname.startsWith('/api/') &&
+    !pathname.startsWith('/status') &&
+    !isFileRequest(pathname)
+  )
+}
+
+const appendVary = (headers: Headers, value: string) => {
+  const current = headers.get('Vary')
+  if (!current) {
+    headers.set('Vary', value)
+    return
+  }
+  if (current.trim() === '*') {
+    return
+  }
+
+  const values = new Set(
+    current
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  )
+  value.split(',').forEach((entry) => {
+    values.add(entry.trim())
+  })
+  headers.set('Vary', [...values].join(', '))
+}
+
+const withGlobalHeaders = (response: Response, request: Request) => {
+  const headers = new Headers(response.headers)
+  headers.set('X-Poi-Codename', 'Shiratsuyu')
+  headers.set('X-Poi-Revision', commitHash)
+  headers.set('X-Poi-Build-Date', buildDate)
+  headers.set('X-Poi-Greetings', 'poi?')
+
+  if (isPageRequest(request)) {
+    headers.set('Accept-CH', clientHintValues)
+    headers.set('Critical-CH', clientHintValues)
+    appendVary(headers, clientHintValues)
+    const contentType = headers.get('Content-Type')
+    if (!contentType || contentType.includes('text/html')) {
+      headers.set('Cache-Control', 'no-store')
+    }
+  }
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
+}
+
+const withAssetHeaders = (response: Response, request: Request) => {
+  const headers = new Headers(response.headers)
+  const { pathname } = new URL(request.url)
+  if (isHashedViteAsset(pathname)) {
+    headers.set('Cache-Control', 'public,max-age=31536000,immutable')
+  } else {
+    headers.set('Cache-Control', 'public,max-age=3600')
+  }
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
+}
+
+const handleMonitoringStub = (request: Request) => {
+  if (request.method === 'POST') {
+    return new Response('', { status: 501 })
+  }
+  return new Response('', {
+    status: 405,
+    headers: {
+      Allow: 'POST',
+    },
+  })
+}
+
+const handleAsset = async (request: Request, env: WorkerEnv) => {
+  if (!env.ASSETS || !isFileRequest(new URL(request.url).pathname)) {
+    return undefined
+  }
+
+  const response = await env.ASSETS.fetch(request)
+  if (response.status === 404) {
+    return undefined
+  }
+
+  return withAssetHeaders(response, request)
+}
+
+const worker = {
+  async fetch(request: Request, env: WorkerEnv) {
+    const { pathname } = new URL(request.url)
+
+    let response: Response | undefined
+    if (pathname === '/api/monitoring') {
+      response = handleMonitoringStub(request)
+    }
+
+    response ??= await handleAsset(request, env)
+    response ??= await startHandler.fetch(request)
+
+    return withGlobalHeaders(response, request)
+  },
+}
+
+export default worker

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,20 @@ import { fileURLToPath } from 'node:url'
 import { cloudflare } from '@cloudflare/vite-plugin'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
+import { execa } from 'execa'
 import { defineConfig } from 'vite'
+
+const getCommitHash = async () => {
+  try {
+    const commitHash = await execa('git', ['rev-parse', 'HEAD'])
+    return commitHash.stdout
+  } catch {
+    return 'development'
+  }
+}
+
+const commitHash = await getCommitHash()
+const buildDate = new Date().toISOString()
 
 export default defineConfig({
   server: {
@@ -18,6 +31,10 @@ export default defineConfig({
     alias: {
       '~': fileURLToPath(new URL('./src', import.meta.url)),
     },
+  },
+  define: {
+    'process.env.BUILD_DATE': JSON.stringify(buildDate),
+    'process.env.COMMIT_HASH': JSON.stringify(commitHash),
   },
   plugins: [
     cloudflare({

--- a/wrangler.tanstack.jsonc
+++ b/wrangler.tanstack.jsonc
@@ -3,7 +3,11 @@
   "name": "poi-web-kai-tanstack-preview",
   "compatibility_date": "2026-06-21",
   "compatibility_flags": ["nodejs_compat"],
-  "main": "@tanstack/react-start/server-entry",
+  "main": "src/worker.ts",
+  "assets": {
+    "directory": "dist/client",
+    "binding": "ASSETS",
+  },
   "observability": {
     "enabled": true,
   },


### PR DESCRIPTION
Closes #485

## Summary

- Adds a custom TanStack Worker entrypoint wrapping the TanStack Start handler.
- Applies global `X-Poi-*` response headers on Worker-handled responses.
- Adds client-hint headers and `Cache-Control: no-store` for request-personalized page HTML, including `HEAD /`.
- Reserves `/api/monitoring` with a method-safe non-localized stub.
- Adds `_headers` cache rules for Vite static assets and favicon.
- Extends TanStack Playwright smoke coverage for global headers, client hints, page no-store, static asset cache headers, and the monitoring route.

## Validation

- `pnpm run lint:next` (passes with existing middleware warning)
- `pnpm run typecheck`
- `pnpm run test:unit`
- `pnpm run build:tanstack`
- `pnpm run test:e2e:tanstack`
- `pnpm run test:e2e:next`

## Notes

- Static files such as `/favicon.ico` are served by the Cloudflare/Vite asset layer before the Worker, so tests assert asset-layer cache behavior and no page/client-hint headers for those assets.
- `vite.config.ts` injects build metadata for the TanStack Worker without touching the existing Next/OpenNext config.
