### PR TITLE
Add TanStack API route adapters

### DIFF
--- a/specs-tanstack/scaffold.spec.ts
+++ b/specs-tanstack/scaffold.spec.ts
@@ -67,3 +67,46 @@ test('reserves monitoring route without locale/page headers', async ({
     expect(response.headers()['accept-ch']).toBeUndefined()
   }
 })
+
+test('serves status through the TanStack Worker route', async ({ request }) => {
+  const response = await request.get('/status', {
+    headers: {
+      'CF-IPCountry': 'JP',
+    },
+  })
+
+  expect(response.status()).toBe(200)
+  expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
+  expect(response.headers()['accept-ch']).toBeUndefined()
+  await expect(response.json()).resolves.toEqual({
+    message: 'poi poi poi!',
+    region: 'JP',
+  })
+})
+
+test('serves dist artifact redirects through the TanStack Worker route', async ({
+  request,
+}) => {
+  const response = await request.get('/dist/poi-10.9.2-win.7z', {
+    maxRedirects: 0,
+  })
+
+  expect(response.status()).toBe(301)
+  expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
+  expect(response.headers().location).toBe(
+    'https://github.com/poooi/poi/releases/download/v10.9.2/poi-10.9.2-win.7z',
+  )
+})
+
+test('serves invalid proxy route inputs as 404 through TanStack', async ({
+  request,
+}) => {
+  const fcdResponse = await request.get('/fcd/meta.md')
+  const updateResponse = await request.get('/update/file.exe')
+  const distResponse = await request.get('/dist/file.exe')
+
+  for (const response of [fcdResponse, updateResponse, distResponse]) {
+    expect(response.status()).toBe(404)
+    expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
+  }
+})

--- a/src/lib/route-handlers.test.ts
+++ b/src/lib/route-handlers.test.ts
@@ -63,6 +63,32 @@ describe('handleFcd', () => {
     await expect(response.json()).resolves.toEqual([{ name: 'map' }])
   })
 
+  it('passes upstream response bodies through as streams', async () => {
+    const target =
+      'https://raw.githubusercontent.com/poooi/poi/master/assets/data/fcd/large.json'
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"items":['))
+        controller.enqueue(new TextEncoder().encode('"large"'))
+        controller.enqueue(new TextEncoder().encode(']}'))
+        controller.close()
+      },
+    })
+    const fetcher = mockFetch({
+      [target]: new Response(body),
+    })
+
+    const response = await handleFcd(
+      makeRequest('/fcd/large.json'),
+      { filename: 'large.json' },
+      { fetcher },
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.body).not.toBeNull()
+    await expect(response.json()).resolves.toEqual({ items: ['large'] })
+  })
+
   it('rejects invalid filenames', async () => {
     const response = await handleFcd(makeRequest('/fcd/meta.md'), {
       filename: 'meta.md',

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,38 +9,101 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as StatusRouteImport } from './routes/status'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as UpdateFilenameRouteImport } from './routes/update.$filename'
+import { Route as FcdFilenameRouteImport } from './routes/fcd.$filename'
+import { Route as DistFilenameRouteImport } from './routes/dist.$filename'
 
+const StatusRoute = StatusRouteImport.update({
+  id: '/status',
+  path: '/status',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const UpdateFilenameRoute = UpdateFilenameRouteImport.update({
+  id: '/update/$filename',
+  path: '/update/$filename',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FcdFilenameRoute = FcdFilenameRouteImport.update({
+  id: '/fcd/$filename',
+  path: '/fcd/$filename',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DistFilenameRoute = DistFilenameRouteImport.update({
+  id: '/dist/$filename',
+  path: '/dist/$filename',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/status': typeof StatusRoute
+  '/dist/$filename': typeof DistFilenameRoute
+  '/fcd/$filename': typeof FcdFilenameRoute
+  '/update/$filename': typeof UpdateFilenameRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/status': typeof StatusRoute
+  '/dist/$filename': typeof DistFilenameRoute
+  '/fcd/$filename': typeof FcdFilenameRoute
+  '/update/$filename': typeof UpdateFilenameRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/status': typeof StatusRoute
+  '/dist/$filename': typeof DistFilenameRoute
+  '/fcd/$filename': typeof FcdFilenameRoute
+  '/update/$filename': typeof UpdateFilenameRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths:
+    | '/'
+    | '/status'
+    | '/dist/$filename'
+    | '/fcd/$filename'
+    | '/update/$filename'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to:
+    | '/'
+    | '/status'
+    | '/dist/$filename'
+    | '/fcd/$filename'
+    | '/update/$filename'
+  id:
+    | '__root__'
+    | '/'
+    | '/status'
+    | '/dist/$filename'
+    | '/fcd/$filename'
+    | '/update/$filename'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  StatusRoute: typeof StatusRoute
+  DistFilenameRoute: typeof DistFilenameRoute
+  FcdFilenameRoute: typeof FcdFilenameRoute
+  UpdateFilenameRoute: typeof UpdateFilenameRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/status': {
+      id: '/status'
+      path: '/status'
+      fullPath: '/status'
+      preLoaderRoute: typeof StatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -48,11 +111,36 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/update/$filename': {
+      id: '/update/$filename'
+      path: '/update/$filename'
+      fullPath: '/update/$filename'
+      preLoaderRoute: typeof UpdateFilenameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fcd/$filename': {
+      id: '/fcd/$filename'
+      path: '/fcd/$filename'
+      fullPath: '/fcd/$filename'
+      preLoaderRoute: typeof FcdFilenameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dist/$filename': {
+      id: '/dist/$filename'
+      path: '/dist/$filename'
+      fullPath: '/dist/$filename'
+      preLoaderRoute: typeof DistFilenameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  StatusRoute: StatusRoute,
+  DistFilenameRoute: DistFilenameRoute,
+  FcdFilenameRoute: FcdFilenameRoute,
+  UpdateFilenameRoute: UpdateFilenameRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/dist.$filename.ts
+++ b/src/routes/dist.$filename.ts
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { handleDist } from '~/lib/route-handlers'
+
+export const Route = createFileRoute('/dist/$filename')({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => handleDist(request, params),
+    },
+  },
+})

--- a/src/routes/fcd.$filename.ts
+++ b/src/routes/fcd.$filename.ts
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { handleFcd } from '~/lib/route-handlers'
+
+export const Route = createFileRoute('/fcd/$filename')({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => handleFcd(request, params),
+    },
+  },
+})

--- a/src/routes/status.ts
+++ b/src/routes/status.ts
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { handleStatus } from '~/lib/route-handlers'
+
+export const Route = createFileRoute('/status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => handleStatus(request),
+    },
+  },
+})

--- a/src/routes/update.$filename.ts
+++ b/src/routes/update.$filename.ts
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { handleUpdate } from '~/lib/route-handlers'
+
+export const Route = createFileRoute('/update/$filename')({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => handleUpdate(request, params),
+    },
+  },
+})


### PR DESCRIPTION
Closes #486

## Summary

- Adds TanStack route adapters for `/status`, `/dist/$filename`, `/fcd/$filename`, and `/update/$filename`.
- Reuses the shared Web-standard handlers from PR 1 instead of reimplementing route behavior.
- Extends TanStack Playwright smoke coverage for status, dist redirects, and invalid proxy inputs.
- Adds unit coverage showing upstream response bodies pass through as streams.

## Validation

- `pnpm run lint:next` (passes with existing middleware warning)
- `pnpm run typecheck`
- `pnpm run test:unit`
- `pnpm run test:e2e:tanstack`
- `pnpm run test:e2e:next`

## Notes

- E2E route tests avoid live GitHub calls. Upstream success/failure behavior remains covered by injected-fetch unit tests.
- Existing Next tests remain in place and still pass.
