### PR TITLE
Add TanStack localized pages

### DIFF
--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -169,6 +169,10 @@ test('does not localize API, proxy, asset, or generated image routes', async ({
     headers: { Cookie: 'NEXT_LOCALE=fr' },
     maxRedirects: 0,
   })
+  const distRootSlashResponse = await request.get('/dist/', {
+    headers: { Cookie: 'NEXT_LOCALE=fr' },
+    maxRedirects: 0,
+  })
   const assetResponse = await request.get('/favicon.ico', {
     headers: { Cookie: 'NEXT_LOCALE=en' },
   })
@@ -178,16 +182,12 @@ test('does not localize API, proxy, asset, or generated image routes', async ({
 
   expect(statusResponse.status()).toBe(200)
   expect(distResponse.status()).toBe(404)
+  expect(distResponse.headers().location).toBeUndefined()
   expect(distRootResponse.status()).toBe(404)
   expect(distRootResponse.headers().location).toBeUndefined()
+  expect(distRootSlashResponse.status()).toBe(404)
+  expect(distRootSlashResponse.headers().location).toBeUndefined()
   expect(assetResponse.status()).toBe(200)
   expect(imageResponse.status()).toBe(200)
   expect(imageResponse.headers()['content-type']).toBe('image/png')
-
-  const distNoExtensionResponse = await request.get('/dist/en', {
-    headers: { Cookie: 'NEXT_LOCALE=fr' },
-    maxRedirects: 0,
-  })
-  expect(distNoExtensionResponse.status()).toBe(404)
-  expect(distNoExtensionResponse.headers().location).toBeUndefined()
 })

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -108,6 +108,7 @@ test('rejects unsupported locale-like prefixes', async ({ request }) => {
 
 test('does not localize API, proxy, asset, or generated image routes', async ({
   request,
+  page,
 }) => {
   const statusResponse = await request.get('/status', {
     headers: { Cookie: 'NEXT_LOCALE=en' },
@@ -123,4 +124,7 @@ test('does not localize API, proxy, asset, or generated image routes', async ({
   expect(assetResponse.status()).toBe(200)
   expect(imageResponse.status()).toBe(200)
   expect(imageResponse.headers()['content-type']).toBe('image/png')
+
+  await page.goto('/dist/en')
+  await expect(page.locator('html')).toHaveAttribute('lang', 'ja')
 })

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -81,6 +81,11 @@ test('canonicalizes default locale prefixes and trailing slashes', async ({
   expect(trailingSlashResponse.headers().location).toBe(
     'http://127.0.0.1:3002/en/download',
   )
+  expect(defaultLocaleResponse.headers()['cache-control']).toBeUndefined()
+  expect(trailingSlashResponse.headers()['cache-control']).toBeUndefined()
+  expect(defaultLocaleResponse.headers()['content-type']).toContain(
+    'text/plain',
+  )
 })
 
 test('serves localized non-default content', async ({ page }) => {

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -92,6 +92,7 @@ test('serves localized non-default content', async ({ page }) => {
     page.getByText('Scalable KanColle browser and tool.'),
   ).toBeVisible()
   await expect(page.getByRole('link', { name: 'Download' })).toBeVisible()
+  await expect(page.getByText('New')).toBeVisible()
 })
 
 test('serves localized download and explore pages', async ({ page }) => {
@@ -110,9 +111,43 @@ test('serves localized download and explore pages', async ({ page }) => {
 test('rejects unsupported locale-like prefixes', async ({ request }) => {
   const localeResponse = await request.get('/es/download')
   const unknownPageResponse = await request.get('/about')
+  const unknownNestedPageResponse = await request.get('/about/team', {
+    headers: { Cookie: 'NEXT_LOCALE=fr' },
+    maxRedirects: 0,
+  })
+  const unknownNestedKnownPageResponse = await request.get('/download/foo', {
+    headers: { Cookie: 'NEXT_LOCALE=fr' },
+    maxRedirects: 0,
+  })
+  const unknownNestedKnownPageSlashResponse = await request.get(
+    '/download/foo/',
+    {
+      headers: { Cookie: 'NEXT_LOCALE=fr' },
+      maxRedirects: 0,
+    },
+  )
+  const unknownDefaultLocaleNestedResponse = await request.get(
+    '/ja/download/foo',
+    {
+      maxRedirects: 0,
+    },
+  )
+  const unknownDefaultLocaleProxyResponse = await request.get('/ja/dist/en', {
+    maxRedirects: 0,
+  })
 
   expect(localeResponse.status()).toBe(404)
   expect(unknownPageResponse.status()).toBe(404)
+  expect(unknownNestedPageResponse.status()).toBe(404)
+  expect(unknownNestedPageResponse.headers().location).toBeUndefined()
+  expect(unknownNestedKnownPageResponse.status()).toBe(404)
+  expect(unknownNestedKnownPageResponse.headers().location).toBeUndefined()
+  expect(unknownNestedKnownPageSlashResponse.status()).toBe(404)
+  expect(unknownNestedKnownPageSlashResponse.headers().location).toBeUndefined()
+  expect(unknownDefaultLocaleNestedResponse.status()).toBe(404)
+  expect(unknownDefaultLocaleNestedResponse.headers().location).toBeUndefined()
+  expect(unknownDefaultLocaleProxyResponse.status()).toBe(404)
+  expect(unknownDefaultLocaleProxyResponse.headers().location).toBeUndefined()
 })
 
 test('does not localize API, proxy, asset, or generated image routes', async ({

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from '@playwright/test'
+
+test('serves default locale content at unprefixed root', async ({ page }) => {
+  await page.context().addCookies([
+    {
+      name: 'NEXT_LOCALE',
+      url: 'http://127.0.0.1:3002',
+      value: 'ja',
+    },
+  ])
+  await page.goto('/')
+
+  await expect(page.getByText(/拡張可能/)).toBeVisible()
+  await expect(page.getByRole('link', { name: 'ダウンロード' })).toBeVisible()
+})
+
+test('redirects locale preference to non-default locale path', async ({
+  request,
+}) => {
+  const response = await request.get('/download?x=1', {
+    headers: {
+      Cookie: 'NEXT_LOCALE=fr',
+    },
+    maxRedirects: 0,
+  })
+
+  expect(response.status()).toBe(307)
+  expect(response.headers().location).toBe(
+    'http://127.0.0.1:3002/fr/download?x=1',
+  )
+  expect(response.headers()['cache-control']).toBe('no-store')
+  expect(response.headers().vary).toContain('Cookie')
+  expect(response.headers().vary).toContain('Accept-Language')
+})
+
+test('canonicalizes default locale prefixes and trailing slashes', async ({
+  request,
+}) => {
+  const defaultLocaleResponse = await request.get('/ja/download', {
+    maxRedirects: 0,
+  })
+  const trailingSlashResponse = await request.get('/en/download/', {
+    maxRedirects: 0,
+  })
+
+  expect(defaultLocaleResponse.status()).toBe(308)
+  expect(defaultLocaleResponse.headers().location).toBe(
+    'http://127.0.0.1:3002/download',
+  )
+  expect(trailingSlashResponse.status()).toBe(308)
+  expect(trailingSlashResponse.headers().location).toBe(
+    'http://127.0.0.1:3002/en/download',
+  )
+})
+
+test('serves localized non-default content', async ({ page }) => {
+  await page.goto('/en')
+
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en')
+  await expect(page).toHaveTitle('poi | KanColle Browser')
+  await expect(
+    page.getByText('Scalable KanColle browser and tool.'),
+  ).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Download' })).toBeVisible()
+})
+
+test('serves localized download and explore pages', async ({ page }) => {
+  await page.goto('/en/download')
+  await expect(page.getByRole('heading', { name: 'Download' })).toBeVisible()
+  await expect(
+    page.getByRole('heading', { name: 'Old versions' }),
+  ).toBeVisible()
+
+  await page.goto('/en/explore')
+  await expect(page.locator('main')).toContainText('poi')
+})
+
+test('rejects unsupported locale-like prefixes', async ({ request }) => {
+  const response = await request.get('/es/download')
+
+  expect(response.status()).toBe(404)
+})
+
+test('does not localize API, proxy, asset, or generated image routes', async ({
+  request,
+}) => {
+  const statusResponse = await request.get('/status', {
+    headers: { Cookie: 'NEXT_LOCALE=en' },
+  })
+  const assetResponse = await request.get('/favicon.ico', {
+    headers: { Cookie: 'NEXT_LOCALE=en' },
+  })
+  const imageResponse = await request.get('/opengraph-image', {
+    headers: { Cookie: 'NEXT_LOCALE=en' },
+  })
+
+  expect(statusResponse.status()).toBe(200)
+  expect(assetResponse.status()).toBe(200)
+  expect(imageResponse.status()).toBe(200)
+  expect(imageResponse.headers()['content-type']).toBe('image/png')
+})

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -17,6 +17,12 @@ test('serves default locale content at unprefixed root', async ({ page }) => {
 test('redirects locale preference to non-default locale path', async ({
   request,
 }) => {
+  const rootResponse = await request.get('/', {
+    headers: {
+      Cookie: 'NEXT_LOCALE=en',
+    },
+    maxRedirects: 0,
+  })
   const response = await request.get('/download?x=1', {
     headers: {
       Cookie: 'NEXT_LOCALE=fr',
@@ -24,6 +30,8 @@ test('redirects locale preference to non-default locale path', async ({
     maxRedirects: 0,
   })
 
+  expect(rootResponse.status()).toBe(307)
+  expect(rootResponse.headers().location).toBe('http://127.0.0.1:3002/en')
   expect(response.status()).toBe(307)
   expect(response.headers().location).toBe(
     'http://127.0.0.1:3002/fr/download?x=1',
@@ -31,6 +39,21 @@ test('redirects locale preference to non-default locale path', async ({
   expect(response.headers()['cache-control']).toBe('no-store')
   expect(response.headers().vary).toContain('Cookie')
   expect(response.headers().vary).toContain('Accept-Language')
+})
+
+test('does not redirect non-GET page requests for locale negotiation', async ({
+  request,
+}) => {
+  const response = await request.post('/download', {
+    data: '',
+    headers: {
+      Cookie: 'NEXT_LOCALE=fr',
+    },
+    maxRedirects: 0,
+  })
+
+  expect(response.status()).not.toBe(307)
+  expect(response.status()).not.toBe(308)
 })
 
 test('canonicalizes default locale prefixes and trailing slashes', async ({
@@ -70,6 +93,8 @@ test('serves localized download and explore pages', async ({ page }) => {
   await expect(
     page.getByRole('heading', { name: 'Old versions' }),
   ).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Nightly builds' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Source code' })).toBeVisible()
 
   await page.goto('/en/explore')
   await expect(page.locator('main')).toContainText('poi')

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -62,12 +62,19 @@ test('canonicalizes default locale prefixes and trailing slashes', async ({
   const defaultLocaleResponse = await request.get('/ja/download', {
     maxRedirects: 0,
   })
+  const defaultLocaleSlashResponse = await request.get('/ja/download/', {
+    maxRedirects: 0,
+  })
   const trailingSlashResponse = await request.get('/en/download/', {
     maxRedirects: 0,
   })
 
   expect(defaultLocaleResponse.status()).toBe(308)
   expect(defaultLocaleResponse.headers().location).toBe(
+    'http://127.0.0.1:3002/download',
+  )
+  expect(defaultLocaleSlashResponse.status()).toBe(308)
+  expect(defaultLocaleSlashResponse.headers().location).toBe(
     'http://127.0.0.1:3002/download',
   )
   expect(trailingSlashResponse.status()).toBe(308)
@@ -101,17 +108,26 @@ test('serves localized download and explore pages', async ({ page }) => {
 })
 
 test('rejects unsupported locale-like prefixes', async ({ request }) => {
-  const response = await request.get('/es/download')
+  const localeResponse = await request.get('/es/download')
+  const unknownPageResponse = await request.get('/about')
 
-  expect(response.status()).toBe(404)
+  expect(localeResponse.status()).toBe(404)
+  expect(unknownPageResponse.status()).toBe(404)
 })
 
 test('does not localize API, proxy, asset, or generated image routes', async ({
   request,
-  page,
 }) => {
   const statusResponse = await request.get('/status', {
     headers: { Cookie: 'NEXT_LOCALE=en' },
+  })
+  const distResponse = await request.get('/dist/en', {
+    headers: { Cookie: 'NEXT_LOCALE=fr' },
+    maxRedirects: 0,
+  })
+  const distRootResponse = await request.get('/dist', {
+    headers: { Cookie: 'NEXT_LOCALE=fr' },
+    maxRedirects: 0,
   })
   const assetResponse = await request.get('/favicon.ico', {
     headers: { Cookie: 'NEXT_LOCALE=en' },
@@ -121,10 +137,17 @@ test('does not localize API, proxy, asset, or generated image routes', async ({
   })
 
   expect(statusResponse.status()).toBe(200)
+  expect(distResponse.status()).toBe(404)
+  expect(distRootResponse.status()).toBe(404)
+  expect(distRootResponse.headers().location).toBeUndefined()
   expect(assetResponse.status()).toBe(200)
   expect(imageResponse.status()).toBe(200)
   expect(imageResponse.headers()['content-type']).toBe('image/png')
 
-  await page.goto('/dist/en')
-  await expect(page.locator('html')).toHaveAttribute('lang', 'ja')
+  const distNoExtensionResponse = await request.get('/dist/en', {
+    headers: { Cookie: 'NEXT_LOCALE=fr' },
+    maxRedirects: 0,
+  })
+  expect(distNoExtensionResponse.status()).toBe(404)
+  expect(distNoExtensionResponse.headers().location).toBeUndefined()
 })

--- a/specs-tanstack/scaffold.spec.ts
+++ b/specs-tanstack/scaffold.spec.ts
@@ -2,13 +2,18 @@ import { expect, test } from '@playwright/test'
 
 test('renders the isolated TanStack preview route', async ({ page }) => {
   await page.emulateMedia({ colorScheme: 'light' })
+  await page.context().addCookies([
+    {
+      name: 'NEXT_LOCALE',
+      url: 'http://127.0.0.1:3002',
+      value: 'ja',
+    },
+  ])
   const response = await page.goto('/')
 
-  await expect(
-    page.getByRole('heading', { name: 'poi TanStack preview' }),
-  ).toBeVisible()
-  await expect(page.getByText('proves the scaffold builds')).toBeVisible()
-  await expect(page.getByRole('link', { name: 'Status route' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'poi' })).toBeVisible()
+  await expect(page.getByText(/拡張可能/)).toBeVisible()
+  await expect(page.getByRole('link', { name: 'ダウンロード' })).toBeVisible()
   await expect(page.locator('body')).toHaveCSS(
     'background-color',
     'rgb(255, 255, 255)',

--- a/src/i18n-config.ts
+++ b/src/i18n-config.ts
@@ -1,4 +1,4 @@
 export const i18nConfig = {
   locales: ['en', 'fr', 'ja', 'ko', 'zh-Hans', 'zh-Hant'],
   defaultLocale: 'ja',
-}
+} as const

--- a/src/lib/i18n-routing.test.ts
+++ b/src/lib/i18n-routing.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolvePreferredLocale } from './i18n-routing'
+import { parseCookieHeader, resolvePreferredLocale } from './i18n-routing'
+
+describe('parseCookieHeader', () => {
+  it('uses a null-prototype cookie map for untrusted cookie names', () => {
+    const cookies = parseCookieHeader('__proto__=polluted; constructor=value')
+
+    expect(Object.getPrototypeOf(cookies)).toBeNull()
+    expect(cookies.__proto__).toBe('polluted')
+    expect(cookies.constructor).toBe('value')
+    expect(Object.prototype).not.toHaveProperty('polluted')
+  })
+})
 
 describe('resolvePreferredLocale', () => {
   it('honors Accept-Language q-values', () => {

--- a/src/lib/i18n-routing.test.ts
+++ b/src/lib/i18n-routing.test.ts
@@ -28,6 +28,12 @@ describe('resolvePreferredLocale', () => {
     ).toBe('zh-Hans')
   })
 
+  it('localizes the root path without adding a trailing slash', async () => {
+    const { localizePath } = await import('./i18n-routing')
+
+    expect(localizePath('/', 'en')).toBe('/en')
+  })
+
   it('maps Chinese script-region tags to script locales', () => {
     expect(
       resolvePreferredLocale(

--- a/src/lib/i18n-routing.test.ts
+++ b/src/lib/i18n-routing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolvePreferredLocale } from './i18n-routing'
+
+describe('resolvePreferredLocale', () => {
+  it('honors Accept-Language q-values', () => {
+    const headers = new Headers({
+      'Accept-Language': 'ja;q=0,en;q=1',
+    })
+
+    expect(resolvePreferredLocale(headers)).toBe('en')
+  })
+
+  it('maps Chinese region tags to script locales', () => {
+    expect(
+      resolvePreferredLocale(
+        new Headers({
+          'Accept-Language': 'zh-TW,zh;q=0.5',
+        }),
+      ),
+    ).toBe('zh-Hant')
+    expect(
+      resolvePreferredLocale(
+        new Headers({
+          'Accept-Language': 'zh-CN,zh;q=0.5',
+        }),
+      ),
+    ).toBe('zh-Hans')
+  })
+
+  it('maps Chinese script-region tags to script locales', () => {
+    expect(
+      resolvePreferredLocale(
+        new Headers({
+          'Accept-Language': 'zh-Hant-TW',
+        }),
+      ),
+    ).toBe('zh-Hant')
+    expect(
+      resolvePreferredLocale(
+        new Headers({
+          'Accept-Language': 'zh-Hans-CN',
+        }),
+      ),
+    ).toBe('zh-Hans')
+  })
+
+  it('ignores malformed locale cookies', () => {
+    expect(
+      resolvePreferredLocale(
+        new Headers({
+          'Accept-Language': 'en',
+          Cookie: 'NEXT_LOCALE=%E0%A4%A',
+        }),
+      ),
+    ).toBe('en')
+  })
+})

--- a/src/lib/i18n-routing.ts
+++ b/src/lib/i18n-routing.ts
@@ -39,7 +39,7 @@ export const localizePath = (pathname: string, locale: string) => {
 }
 
 export const parseCookieHeader = (cookieHeader: string | null) => {
-  const cookies: Record<string, string> = {}
+  const cookies = Object.create(null) as Record<string, string>
   for (const entry of (cookieHeader ?? '').split(';')) {
     const trimmed = entry.trim()
     if (!trimmed) {

--- a/src/lib/i18n-routing.ts
+++ b/src/lib/i18n-routing.ts
@@ -1,0 +1,134 @@
+import { i18nConfig } from '~/i18n-config'
+
+export const defaultLocale = i18nConfig.defaultLocale
+
+export const supportedLocales = i18nConfig.locales
+
+export type SupportedLocale = (typeof supportedLocales)[number]
+
+export const isSupportedLocale = (
+  locale: string,
+): locale is SupportedLocale => {
+  return (supportedLocales as readonly string[]).includes(locale)
+}
+
+export const isDefaultLocale = (locale: string) => locale === defaultLocale
+
+export const getPathLocale = (pathname: string) => {
+  const segment = pathname.split('/').find(Boolean)
+  return segment && isSupportedLocale(segment) ? segment : undefined
+}
+
+export const stripLocalePrefix = (pathname: string) => {
+  const locale = getPathLocale(pathname)
+  if (!locale) {
+    return pathname
+  }
+
+  const stripped = pathname.replace(new RegExp(`^/${locale}`), '')
+  return stripped || '/'
+}
+
+export const localizePath = (pathname: string, locale: string) => {
+  const stripped = stripLocalePrefix(pathname)
+  if (isDefaultLocale(locale)) {
+    return stripped
+  }
+
+  return stripped === '/' ? `/${locale}/` : `/${locale}${stripped}`
+}
+
+export const parseCookieHeader = (cookieHeader: string | null) => {
+  const cookies: Record<string, string> = {}
+  for (const entry of (cookieHeader ?? '').split(';')) {
+    const trimmed = entry.trim()
+    if (!trimmed) {
+      continue
+    }
+
+    const [key, ...value] = trimmed.split('=')
+    if (key) {
+      try {
+        cookies[key] = decodeURIComponent(value.join('='))
+      } catch {
+        // Ignore malformed cookie values instead of failing request routing.
+      }
+    }
+  }
+
+  return cookies
+}
+
+const parseAcceptLanguage = (acceptLanguage: string) => {
+  return acceptLanguage
+    .split(',')
+    .map((entry, index) => {
+      const [language = '', ...parameters] = entry
+        .trim()
+        .split(';')
+        .map((part) => part.trim())
+      const qParameter = parameters.find((parameter) =>
+        parameter.startsWith('q='),
+      )
+      const q = qParameter ? Number(qParameter.slice(2)) : 1
+      return {
+        index,
+        language,
+        q: Number.isFinite(q) ? q : 0,
+      }
+    })
+    .filter(({ language, q }) => language && q > 0)
+    .sort((a, b) => b.q - a.q || a.index - b.index)
+}
+
+const matchAcceptedLanguage = (language: string) => {
+  if (isSupportedLocale(language)) {
+    return language
+  }
+
+  const normalized = language.toLowerCase()
+  if (
+    normalized === 'zh-hant' ||
+    normalized.startsWith('zh-hant-') ||
+    normalized === 'zh-tw' ||
+    normalized === 'zh-hk' ||
+    normalized === 'zh-mo'
+  ) {
+    return 'zh-Hant'
+  }
+
+  if (
+    normalized === 'zh' ||
+    normalized === 'zh-hans' ||
+    normalized.startsWith('zh-hans-') ||
+    normalized === 'zh-cn' ||
+    normalized === 'zh-sg' ||
+    normalized === 'zh-my'
+  ) {
+    return 'zh-Hans'
+  }
+
+  const baseLocale = normalized.includes('-')
+    ? normalized.slice(0, normalized.indexOf('-'))
+    : normalized
+  return supportedLocales.find(
+    (supportedLocale) => supportedLocale.toLowerCase() === baseLocale,
+  )
+}
+
+export const resolvePreferredLocale = (headers: Headers) => {
+  const cookieLocale = parseCookieHeader(headers.get('Cookie')).NEXT_LOCALE
+  if (cookieLocale && isSupportedLocale(cookieLocale)) {
+    return cookieLocale
+  }
+
+  const acceptLanguage = headers.get('Accept-Language') ?? ''
+  for (const { language } of parseAcceptLanguage(acceptLanguage)) {
+    const supported = matchAcceptedLanguage(language)
+    if (supported) {
+      return supported
+    }
+  }
+
+  return defaultLocale
+}

--- a/src/lib/i18n-routing.ts
+++ b/src/lib/i18n-routing.ts
@@ -35,7 +35,7 @@ export const localizePath = (pathname: string, locale: string) => {
     return stripped
   }
 
-  return stripped === '/' ? `/${locale}/` : `/${locale}${stripped}`
+  return stripped === '/' ? `/${locale}` : `/${locale}${stripped}`
 }
 
 export const parseCookieHeader = (cookieHeader: string | null) => {

--- a/src/lib/tanstack-page-data.ts
+++ b/src/lib/tanstack-page-data.ts
@@ -19,6 +19,8 @@ const exploreContentByLocale = import.meta.glob<string>(
   },
 )
 
+const exploreHtmlByLocale = new Map<SupportedLocale, string>()
+
 export const requireSupportedLocale = (locale: string): SupportedLocale => {
   if (!isSupportedLocale(locale)) {
     // TanStack route loaders consume thrown Responses for HTTP status control.
@@ -53,6 +55,11 @@ export const loadCommonTranslations = async (
 
 export const loadExploreHtml = async (locale: string = defaultLocale) => {
   const supportedLocale = requireSupportedLocale(locale)
+  const cachedHtml = exploreHtmlByLocale.get(supportedLocale)
+  if (cachedHtml !== undefined) {
+    return cachedHtml
+  }
+
   const content =
     exploreContentByLocale[`../contents/explore/${supportedLocale}.md`]
   if (!content) {
@@ -61,7 +68,9 @@ export const loadExploreHtml = async (locale: string = defaultLocale) => {
     throw new Response('', { status: 404 })
   }
 
-  return (
+  const html = (
     await remark().use(rehype).use(sanitize).use(stringify).process(content)
   ).toString()
+  exploreHtmlByLocale.set(supportedLocale, html)
+  return html
 }

--- a/src/lib/tanstack-page-data.ts
+++ b/src/lib/tanstack-page-data.ts
@@ -1,5 +1,7 @@
+import sanitize from 'rehype-sanitize'
+import stringify from 'rehype-stringify'
 import { remark } from 'remark'
-import html from 'remark-html'
+import rehype from 'remark-rehype'
 
 import { initTranslations } from '~/i18n'
 import {
@@ -58,5 +60,7 @@ export const loadExploreHtml = async (locale: string = defaultLocale) => {
     throw new Response('', { status: 404 })
   }
 
-  return (await remark().use(html).process(content)).toString()
+  return (
+    await remark().use(rehype).use(sanitize).use(stringify).process(content)
+  ).toString()
 }

--- a/src/lib/tanstack-page-data.ts
+++ b/src/lib/tanstack-page-data.ts
@@ -1,0 +1,62 @@
+import { remark } from 'remark'
+import html from 'remark-html'
+
+import { initTranslations } from '~/i18n'
+import {
+  defaultLocale,
+  isSupportedLocale,
+  type SupportedLocale,
+} from '~/lib/i18n-routing'
+
+const exploreContentByLocale = import.meta.glob<string>(
+  '../contents/explore/*.md',
+  {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  },
+)
+
+export const requireSupportedLocale = (locale: string): SupportedLocale => {
+  if (!isSupportedLocale(locale)) {
+    // TanStack route loaders consume thrown Responses for HTTP status control.
+    // eslint-disable-next-line @typescript-eslint/only-throw-error
+    throw new Response('', { status: 404 })
+  }
+
+  return locale
+}
+
+export const loadCommonTranslations = async (
+  locale: string = defaultLocale,
+) => {
+  const supportedLocale = requireSupportedLocale(locale)
+  const { t } = await initTranslations(supportedLocale, ['common'])
+  return {
+    description: t('description'),
+    download: t('Download'),
+    downloadOptions: t('Download options'),
+    explore: t('Explore'),
+    httpsUpdateSupported: t('HTTPS game update supported!'),
+    language: t('language'),
+    mobileHint: t('mobile-hint'),
+    name: t('name'),
+    nightlyBuilds: t('Nightly builds'),
+    oldVersions: t('Old versions'),
+    sourceCode: t('Source code'),
+    title: t('KanColle Browser'),
+  }
+}
+
+export const loadExploreHtml = async (locale: string = defaultLocale) => {
+  const supportedLocale = requireSupportedLocale(locale)
+  const content =
+    exploreContentByLocale[`../contents/explore/${supportedLocale}.md`]
+  if (!content) {
+    // TanStack route loaders consume thrown Responses for HTTP status control.
+    // eslint-disable-next-line @typescript-eslint/only-throw-error
+    throw new Response('', { status: 404 })
+  }
+
+  return (await remark().use(html).process(content)).toString()
+}

--- a/src/lib/tanstack-page-data.ts
+++ b/src/lib/tanstack-page-data.ts
@@ -43,6 +43,7 @@ export const loadCommonTranslations = async (
     language: t('language'),
     mobileHint: t('mobile-hint'),
     name: t('name'),
+    newLabel: t('New'),
     nightlyBuilds: t('Nightly builds'),
     oldVersions: t('Old versions'),
     sourceCode: t('Source code'),

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -20,6 +20,7 @@
   "Now Loading": "Now Loading",
   "Stable": "Stable",
   "Beta": "Beta",
+  "New": "New",
   "Others": "Others",
   "HostedAt": "Hosted at {{site}}",
   "Old versions": "Old versions",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -19,6 +19,7 @@
   "Now Loading": "En cours de chargement",
   "Stable": "Stable",
   "Beta": "Beta",
+  "New": "Nouveau",
   "Others": "Autres",
   "HostedAt": "Hébergé sur {{site}}",
   "Old versions": "Anciennes versions",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -22,6 +22,7 @@
   "Now Loading": "少女祈祷中",
   "Stable": "安定版",
   "Beta": "開発版",
+  "New": "新着",
   "Others": "他",
   "HostedAt": "{{site}} でホストされています",
   "Old versions": "旧版",

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -21,6 +21,7 @@
   "Now Loading": "로딩중",
   "Stable": "안정 버전",
   "Beta": "베타 버전",
+  "New": "신규",
   "Others": "기타",
   "HostedAt": "{{site}}에서 호스팅 중",
   "Old versions": "오래된 버전",

--- a/src/locales/zh-Hans/common.json
+++ b/src/locales/zh-Hans/common.json
@@ -22,6 +22,7 @@
   "Now Loading": "少女祈祷中",
   "Stable": "正式版",
   "Beta": "测试版",
+  "New": "新",
   "Others": "其它",
   "HostedAt": "托管于 {{site}}",
   "Old versions": "历史版本",

--- a/src/locales/zh-Hant/common.json
+++ b/src/locales/zh-Hant/common.json
@@ -22,6 +22,7 @@
   "Now Loading": "少女祈禱中",
   "Stable": "正式版",
   "Beta": "測試版",
+  "New": "新",
   "Others": "其它",
   "HostedAt": "託管於 {{site}}",
   "Old versions": "歷史版本",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,10 +12,15 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as TwitterImageRouteImport } from './routes/twitter-image'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as OpengraphImageRouteImport } from './routes/opengraph-image'
+import { Route as ExploreRouteImport } from './routes/explore'
+import { Route as DownloadRouteImport } from './routes/download'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as LocaleIndexRouteImport } from './routes/$locale.index'
 import { Route as UpdateFilenameRouteImport } from './routes/update.$filename'
 import { Route as FcdFilenameRouteImport } from './routes/fcd.$filename'
 import { Route as DistFilenameRouteImport } from './routes/dist.$filename'
+import { Route as LocaleExploreRouteImport } from './routes/$locale.explore'
+import { Route as LocaleDownloadRouteImport } from './routes/$locale.download'
 
 const TwitterImageRoute = TwitterImageRouteImport.update({
   id: '/twitter-image',
@@ -32,9 +37,24 @@ const OpengraphImageRoute = OpengraphImageRouteImport.update({
   path: '/opengraph-image',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ExploreRoute = ExploreRouteImport.update({
+  id: '/explore',
+  path: '/explore',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DownloadRoute = DownloadRouteImport.update({
+  id: '/download',
+  path: '/download',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LocaleIndexRoute = LocaleIndexRouteImport.update({
+  id: '/$locale/',
+  path: '/$locale/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const UpdateFilenameRoute = UpdateFilenameRouteImport.update({
@@ -52,73 +72,118 @@ const DistFilenameRoute = DistFilenameRouteImport.update({
   path: '/dist/$filename',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LocaleExploreRoute = LocaleExploreRouteImport.update({
+  id: '/$locale/explore',
+  path: '/$locale/explore',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LocaleDownloadRoute = LocaleDownloadRouteImport.update({
+  id: '/$locale/download',
+  path: '/$locale/download',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/download': typeof DownloadRoute
+  '/explore': typeof ExploreRoute
   '/opengraph-image': typeof OpengraphImageRoute
   '/status': typeof StatusRoute
   '/twitter-image': typeof TwitterImageRoute
+  '/$locale/download': typeof LocaleDownloadRoute
+  '/$locale/explore': typeof LocaleExploreRoute
   '/dist/$filename': typeof DistFilenameRoute
   '/fcd/$filename': typeof FcdFilenameRoute
   '/update/$filename': typeof UpdateFilenameRoute
+  '/$locale/': typeof LocaleIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/download': typeof DownloadRoute
+  '/explore': typeof ExploreRoute
   '/opengraph-image': typeof OpengraphImageRoute
   '/status': typeof StatusRoute
   '/twitter-image': typeof TwitterImageRoute
+  '/$locale/download': typeof LocaleDownloadRoute
+  '/$locale/explore': typeof LocaleExploreRoute
   '/dist/$filename': typeof DistFilenameRoute
   '/fcd/$filename': typeof FcdFilenameRoute
   '/update/$filename': typeof UpdateFilenameRoute
+  '/$locale': typeof LocaleIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/download': typeof DownloadRoute
+  '/explore': typeof ExploreRoute
   '/opengraph-image': typeof OpengraphImageRoute
   '/status': typeof StatusRoute
   '/twitter-image': typeof TwitterImageRoute
+  '/$locale/download': typeof LocaleDownloadRoute
+  '/$locale/explore': typeof LocaleExploreRoute
   '/dist/$filename': typeof DistFilenameRoute
   '/fcd/$filename': typeof FcdFilenameRoute
   '/update/$filename': typeof UpdateFilenameRoute
+  '/$locale/': typeof LocaleIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/download'
+    | '/explore'
     | '/opengraph-image'
     | '/status'
     | '/twitter-image'
+    | '/$locale/download'
+    | '/$locale/explore'
     | '/dist/$filename'
     | '/fcd/$filename'
     | '/update/$filename'
+    | '/$locale/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/download'
+    | '/explore'
     | '/opengraph-image'
     | '/status'
     | '/twitter-image'
+    | '/$locale/download'
+    | '/$locale/explore'
     | '/dist/$filename'
     | '/fcd/$filename'
     | '/update/$filename'
+    | '/$locale'
   id:
     | '__root__'
     | '/'
+    | '/download'
+    | '/explore'
     | '/opengraph-image'
     | '/status'
     | '/twitter-image'
+    | '/$locale/download'
+    | '/$locale/explore'
     | '/dist/$filename'
     | '/fcd/$filename'
     | '/update/$filename'
+    | '/$locale/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  DownloadRoute: typeof DownloadRoute
+  ExploreRoute: typeof ExploreRoute
   OpengraphImageRoute: typeof OpengraphImageRoute
   StatusRoute: typeof StatusRoute
   TwitterImageRoute: typeof TwitterImageRoute
+  LocaleDownloadRoute: typeof LocaleDownloadRoute
+  LocaleExploreRoute: typeof LocaleExploreRoute
   DistFilenameRoute: typeof DistFilenameRoute
   FcdFilenameRoute: typeof FcdFilenameRoute
   UpdateFilenameRoute: typeof UpdateFilenameRoute
+  LocaleIndexRoute: typeof LocaleIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -144,11 +209,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OpengraphImageRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/explore': {
+      id: '/explore'
+      path: '/explore'
+      fullPath: '/explore'
+      preLoaderRoute: typeof ExploreRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/download': {
+      id: '/download'
+      path: '/download'
+      fullPath: '/download'
+      preLoaderRoute: typeof DownloadRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$locale/': {
+      id: '/$locale/'
+      path: '/$locale'
+      fullPath: '/$locale/'
+      preLoaderRoute: typeof LocaleIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/update/$filename': {
@@ -172,17 +258,36 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DistFilenameRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/$locale/explore': {
+      id: '/$locale/explore'
+      path: '/$locale/explore'
+      fullPath: '/$locale/explore'
+      preLoaderRoute: typeof LocaleExploreRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$locale/download': {
+      id: '/$locale/download'
+      path: '/$locale/download'
+      fullPath: '/$locale/download'
+      preLoaderRoute: typeof LocaleDownloadRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  DownloadRoute: DownloadRoute,
+  ExploreRoute: ExploreRoute,
   OpengraphImageRoute: OpengraphImageRoute,
   StatusRoute: StatusRoute,
   TwitterImageRoute: TwitterImageRoute,
+  LocaleDownloadRoute: LocaleDownloadRoute,
+  LocaleExploreRoute: LocaleExploreRoute,
   DistFilenameRoute: DistFilenameRoute,
   FcdFilenameRoute: FcdFilenameRoute,
   UpdateFilenameRoute: UpdateFilenameRoute,
+  LocaleIndexRoute: LocaleIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/$locale.download.tsx
+++ b/src/routes/$locale.download.tsx
@@ -1,0 +1,44 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Button } from '~/components/ui/button'
+import {
+  loadCommonTranslations,
+  requireSupportedLocale,
+} from '~/lib/tanstack-page-data'
+
+export const Route = createFileRoute('/$locale/download')({
+  loader: ({ params }) =>
+    loadCommonTranslations(requireSupportedLocale(params.locale)),
+  head: ({ loaderData }) => ({
+    meta: [
+      {
+        title: `poi | ${loaderData?.title ?? 'KanColle Browser'} | ${
+          loaderData?.download ?? 'Download'
+        }`,
+      },
+    ],
+  }),
+  component: LocalizedDownloadPage,
+})
+
+function LocalizedDownloadPage() {
+  const t = Route.useLoaderData()
+  return (
+    <main className="prose mx-auto flex min-h-screen max-w-[960px] flex-col justify-center p-4 dark:prose-invert">
+      <h1>{t.download}</h1>
+      <p>{t.mobileHint}</p>
+      <h2>{t.oldVersions}</h2>
+      <div>
+        <Button variant="link" asChild>
+          <a
+            href="https://registry.npmmirror.com/binary.html?path=poi/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {t.oldVersions}
+          </a>
+        </Button>
+      </div>
+    </main>
+  )
+}

--- a/src/routes/$locale.download.tsx
+++ b/src/routes/$locale.download.tsx
@@ -38,6 +38,24 @@ function LocalizedDownloadPage() {
             {t.oldVersions}
           </a>
         </Button>
+        <Button variant="link" asChild>
+          <a
+            href="https://nightly.poi.moe/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {t.nightlyBuilds}
+          </a>
+        </Button>
+        <Button variant="link" asChild>
+          <a
+            href="https://github.com/poooi/poi"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {t.sourceCode}
+          </a>
+        </Button>
       </div>
     </main>
   )

--- a/src/routes/$locale.explore.tsx
+++ b/src/routes/$locale.explore.tsx
@@ -1,0 +1,37 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import {
+  loadCommonTranslations,
+  loadExploreHtml,
+  requireSupportedLocale,
+} from '~/lib/tanstack-page-data'
+
+export const Route = createFileRoute('/$locale/explore')({
+  loader: async ({ params }) => {
+    const locale = requireSupportedLocale(params.locale)
+    return {
+      ...(await loadCommonTranslations(locale)),
+      contentHtml: await loadExploreHtml(locale),
+    }
+  },
+  head: ({ loaderData }) => ({
+    meta: [
+      {
+        title: `poi | ${loaderData?.title ?? 'KanColle Browser'} | ${
+          loaderData?.explore ?? 'Explore'
+        }`,
+      },
+    ],
+  }),
+  component: LocalizedExplorePage,
+})
+
+function LocalizedExplorePage() {
+  const { contentHtml } = Route.useLoaderData()
+  return (
+    <main
+      className="prose mx-auto min-h-screen max-w-[960px] p-4 dark:prose-invert"
+      dangerouslySetInnerHTML={{ __html: contentHtml }}
+    />
+  )
+}

--- a/src/routes/$locale.index.tsx
+++ b/src/routes/$locale.index.tsx
@@ -37,7 +37,7 @@ function LocalizedHomePage() {
       </div>
       <div className="flex items-center gap-2">
         <Badge variant="outline" className="bg-green-500 text-white">
-          New
+          {t.newLabel}
         </Badge>
         <span>{t.httpsUpdateSupported}</span>
       </div>

--- a/src/routes/$locale.index.tsx
+++ b/src/routes/$locale.index.tsx
@@ -2,28 +2,37 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
-import { loadCommonTranslations } from '~/lib/tanstack-page-data'
+import {
+  loadCommonTranslations,
+  requireSupportedLocale,
+} from '~/lib/tanstack-page-data'
 
-export const Route = createFileRoute('/')({
-  loader: () => loadCommonTranslations(),
+export const Route = createFileRoute('/$locale/')({
+  loader: ({ params }) =>
+    loadCommonTranslations(requireSupportedLocale(params.locale)),
   head: ({ loaderData }) => ({
-    meta: [{ title: `poi | ${loaderData?.title ?? '艦これ専ブラ'}` }],
+    meta: [{ title: `poi | ${loaderData?.title ?? 'KanColle Browser'}` }],
   }),
-  component: HomePage,
+  component: LocalizedHomePage,
 })
 
-function HomePage() {
+function LocalizedHomePage() {
   const t = Route.useLoaderData()
+  const { locale } = Route.useParams()
   return (
     <main className="mx-auto flex min-h-screen max-w-[960px] flex-col items-start justify-center gap-6 bg-background p-4 text-foreground">
       <h1 className="text-7xl leading-loose">{t.name}</h1>
       <p className="text-2xl">{t.description}</p>
       <div className="flex gap-4">
         <Button asChild>
-          <Link to="/download">{t.download}</Link>
+          <Link to="/$locale/download" params={{ locale }}>
+            {t.download}
+          </Link>
         </Button>
         <Button variant="secondary" asChild>
-          <Link to="/explore">{t.explore}</Link>
+          <Link to="/$locale/explore" params={{ locale }}>
+            {t.explore}
+          </Link>
         </Button>
       </div>
       <div className="flex items-center gap-2">

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,8 +1,14 @@
 /* eslint-disable @next/next/no-css-tags */
 /* eslint-disable @next/next/no-head-element */
-import { createRootRoute, HeadContent, Scripts } from '@tanstack/react-router'
+import {
+  createRootRoute,
+  HeadContent,
+  Scripts,
+  useRouterState,
+} from '@tanstack/react-router'
 
 import '~/styles/globals.css'
+import { defaultLocale, isSupportedLocale } from '~/lib/i18n-routing'
 
 export const Route = createRootRoute({
   head: () => ({
@@ -13,22 +19,40 @@ export const Route = createRootRoute({
         content: 'width=device-width, initial-scale=1',
       },
       {
-        title: 'poi TanStack preview',
+        title: 'poi',
       },
+      {
+        name: 'description',
+        content:
+          'Scalable KanColle browser and tool, for Windows, macOS and Linux. 一个可扩展的舰队Collectionブラウザ。拡張可能な艦隊これくしょんブラウザ。',
+      },
+    ],
+    links: [
+      { rel: 'icon', href: '/favicon.ico' },
+      { rel: 'stylesheet', href: '/fonts/plex-sans/IBMPlexSans-Regular.css' },
     ],
   }),
   shellComponent: RootDocument,
 })
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  const locale = useRouterState({
+    select: (state) => {
+      return (
+        state.matches
+          .flatMap((match) => Object.values(match.params))
+          .find(
+            (param): param is string =>
+              typeof param === 'string' && isSupportedLocale(param),
+          ) ?? defaultLocale
+      )
+    },
+  })
+
   return (
-    <html lang="ja">
+    <html lang={locale}>
       <head>
         <HeadContent />
-        <link
-          href="/fonts/plex-sans/IBMPlexSans-Regular.css"
-          rel="stylesheet"
-        />
       </head>
       <body>
         {children}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -38,14 +38,15 @@ export const Route = createRootRoute({
 function RootDocument({ children }: { children: React.ReactNode }) {
   const locale = useRouterState({
     select: (state) => {
-      return (
-        state.matches
-          .flatMap((match) => Object.values(match.params))
-          .find(
-            (param): param is string =>
-              typeof param === 'string' && isSupportedLocale(param),
-          ) ?? defaultLocale
-      )
+      const routeLocale = state.matches
+        .map((match) => {
+          return 'locale' in match.params ? match.params.locale : undefined
+        })
+        .find(
+          (param): param is string =>
+            typeof param === 'string' && isSupportedLocale(param),
+        )
+      return routeLocale ?? defaultLocale
     },
   })
 

--- a/src/routes/download.tsx
+++ b/src/routes/download.tsx
@@ -1,0 +1,58 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Button } from '~/components/ui/button'
+import { loadCommonTranslations } from '~/lib/tanstack-page-data'
+
+export const Route = createFileRoute('/download')({
+  loader: () => loadCommonTranslations(),
+  head: ({ loaderData }) => ({
+    meta: [
+      {
+        title: `poi | ${loaderData?.title ?? 'KanColle Browser'} | ${
+          loaderData?.download ?? 'Download'
+        }`,
+      },
+    ],
+  }),
+  component: DownloadPage,
+})
+
+function DownloadPage() {
+  const t = Route.useLoaderData()
+  return (
+    <main className="prose mx-auto flex min-h-screen max-w-[960px] flex-col justify-center p-4 dark:prose-invert">
+      <h1>{t.download}</h1>
+      <p>{t.mobileHint}</p>
+      <h2>{t.oldVersions}</h2>
+      <div>
+        <Button variant="link" asChild>
+          <a
+            href="https://registry.npmmirror.com/binary.html?path=poi/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {t.oldVersions}
+          </a>
+        </Button>
+        <Button variant="link" asChild>
+          <a
+            href="https://nightly.poi.moe/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {t.nightlyBuilds}
+          </a>
+        </Button>
+        <Button variant="link" asChild>
+          <a
+            href="https://github.com/poooi/poi"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {t.sourceCode}
+          </a>
+        </Button>
+      </div>
+    </main>
+  )
+}

--- a/src/routes/explore.tsx
+++ b/src/routes/explore.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import {
+  loadCommonTranslations,
+  loadExploreHtml,
+} from '~/lib/tanstack-page-data'
+
+export const Route = createFileRoute('/explore')({
+  loader: async () => ({
+    ...(await loadCommonTranslations()),
+    contentHtml: await loadExploreHtml(),
+  }),
+  head: ({ loaderData }) => ({
+    meta: [
+      {
+        title: `poi | ${loaderData?.title ?? 'KanColle Browser'} | ${
+          loaderData?.explore ?? 'Explore'
+        }`,
+      },
+    ],
+  }),
+  component: ExplorePage,
+})
+
+function ExplorePage() {
+  const { contentHtml } = Route.useLoaderData()
+  return (
+    <main
+      className="prose mx-auto min-h-screen max-w-[960px] p-4 dark:prose-invert"
+      dangerouslySetInnerHTML={{ __html: contentHtml }}
+    />
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -28,7 +28,7 @@ function HomePage() {
       </div>
       <div className="flex items-center gap-2">
         <Badge variant="outline" className="bg-green-500 text-white">
-          New
+          {t.newLabel}
         </Badge>
         <span>{t.httpsUpdateSupported}</span>
       </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -107,6 +107,37 @@ const handleLocaleRedirects = (request: Request) => {
     return undefined
   }
 
+  const pathSegments = pathname.split('/').filter(Boolean)
+  const firstSegment = pathSegments[0]
+  const secondSegment = pathSegments[1]
+  const knownUnprefixedPage =
+    pathSegments.length === 1 &&
+    (firstSegment === 'download' || firstSegment === 'explore')
+  const knownDefaultPage = pathSegments.length === 0 || knownUnprefixedPage
+  const localeShapedSegment =
+    !!firstSegment && /^[a-z]{2}(?:-[A-Za-z]+)?$/.test(firstSegment)
+  const supportedLocalizedPage =
+    firstSegment &&
+    isSupportedLocale(firstSegment) &&
+    (pathSegments.length === 1 ||
+      (pathSegments.length === 2 &&
+        (secondSegment === 'download' || secondSegment === 'explore')))
+  const knownLocalizedPage =
+    firstSegment &&
+    !knownUnprefixedPage &&
+    !isSupportedLocale(firstSegment) &&
+    (pathSegments.length === 1 ||
+      (localeShapedSegment &&
+        pathSegments.length === 2 &&
+        (secondSegment === 'download' || secondSegment === 'explore')))
+  if (knownLocalizedPage) {
+    return new Response('', { status: 404 })
+  }
+
+  if (!knownDefaultPage && !supportedLocalizedPage) {
+    return new Response('', { status: 404 })
+  }
+
   const locale = getPathLocale(pathname)
   let canonicalPathname = pathname
   if (canonicalPathname !== '/' && canonicalPathname.endsWith('/')) {
@@ -118,24 +149,6 @@ const handleLocaleRedirects = (request: Request) => {
 
   if (canonicalPathname !== pathname) {
     return redirectTo(request, canonicalPathname, 308)
-  }
-
-  const pathSegments = pathname.split('/').filter(Boolean)
-  const firstSegment = pathSegments[0]
-  const secondSegment = pathSegments[1]
-  const knownUnprefixedPage =
-    firstSegment === 'download' || firstSegment === 'explore'
-  const localeShapedSegment =
-    !!firstSegment && /^[a-z]{2}(?:-[A-Za-z]+)?$/.test(firstSegment)
-  const knownLocalizedPage =
-    firstSegment &&
-    !knownUnprefixedPage &&
-    !isSupportedLocale(firstSegment) &&
-    (pathSegments.length === 1 ||
-      (localeShapedSegment &&
-        (secondSegment === 'download' || secondSegment === 'explore')))
-  if (knownLocalizedPage) {
-    return new Response('', { status: 404 })
   }
 
   if (!locale) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -91,6 +91,10 @@ const redirectTo = (request: Request, pathname: string, status: 307 | 308) => {
 
 const handleLocaleRedirects = (request: Request) => {
   const { pathname } = new URL(request.url)
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return undefined
+  }
+
   if (!isPagePath(pathname)) {
     return undefined
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,15 @@
 import startHandler from '@tanstack/react-start/server-entry'
 
+import {
+  defaultLocale,
+  getPathLocale,
+  isDefaultLocale,
+  isSupportedLocale,
+  localizePath,
+  resolvePreferredLocale,
+  stripLocalePrefix,
+} from '~/lib/i18n-routing'
+
 interface AssetsBinding {
   fetch(request: Request): Promise<Response>
 }
@@ -51,6 +61,72 @@ const isPageRequest = (request: Request) => {
     !isSocialImagePath(pathname) &&
     !isFileRequest(pathname)
   )
+}
+
+const isPagePath = (pathname: string) => {
+  return (
+    !pathname.startsWith('/api/') &&
+    !pathname.startsWith('/status') &&
+    !isSocialImagePath(pathname) &&
+    !isFileRequest(pathname)
+  )
+}
+
+const redirectTo = (request: Request, pathname: string, status: 307 | 308) => {
+  const url = new URL(request.url)
+  url.pathname = pathname
+  const headers = new Headers()
+  if (status === 307) {
+    headers.set('Cache-Control', 'no-store')
+    headers.set('Vary', 'Cookie, Accept-Language')
+  }
+  return new Response('', {
+    headers: {
+      ...Object.fromEntries(headers),
+      Location: url.toString(),
+    },
+    status,
+  })
+}
+
+const handleLocaleRedirects = (request: Request) => {
+  const { pathname } = new URL(request.url)
+  if (!isPagePath(pathname)) {
+    return undefined
+  }
+
+  if (pathname !== '/' && pathname.endsWith('/')) {
+    return redirectTo(request, pathname.replace(/\/+$/, ''), 308)
+  }
+
+  const locale = getPathLocale(pathname)
+  if (locale && isDefaultLocale(locale)) {
+    return redirectTo(request, stripLocalePrefix(pathname), 308)
+  }
+
+  const firstSegment = pathname.split('/').find(Boolean)
+  const secondSegment = pathname.split('/').filter(Boolean)[1]
+  const knownUnprefixedPage =
+    firstSegment === 'download' || firstSegment === 'explore'
+  const knownLocalizedPage =
+    firstSegment &&
+    !knownUnprefixedPage &&
+    !isSupportedLocale(firstSegment) &&
+    (secondSegment === undefined ||
+      secondSegment === 'download' ||
+      secondSegment === 'explore')
+  if (knownLocalizedPage) {
+    return new Response('', { status: 404 })
+  }
+
+  if (!locale) {
+    const preferredLocale = resolvePreferredLocale(request.headers)
+    if (preferredLocale !== defaultLocale) {
+      return redirectTo(request, localizePath(pathname, preferredLocale), 307)
+    }
+  }
+
+  return undefined
 }
 
 const appendVary = (headers: Headers, value: string) => {
@@ -152,6 +228,7 @@ const worker = {
       response = handleMonitoringStub(request)
     }
 
+    response ??= handleLocaleRedirects(request)
     response ??= await handleAsset(request, env)
     response ??= await (startHandler.fetch as StartHandlerWithContext)(
       request,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -52,6 +52,10 @@ const isSocialImagePath = (pathname: string) => {
   return normalized === '/opengraph-image' || normalized === '/twitter-image'
 }
 
+const isProxyRootPath = (pathname: string) => {
+  return pathname === '/dist' || pathname === '/fcd' || pathname === '/update'
+}
+
 const isPageRequest = (request: Request) => {
   const { pathname } = new URL(request.url)
   return (
@@ -67,6 +71,10 @@ const isPagePath = (pathname: string) => {
   return (
     !pathname.startsWith('/api/') &&
     !pathname.startsWith('/status') &&
+    !isProxyRootPath(pathname) &&
+    !pathname.startsWith('/dist/') &&
+    !pathname.startsWith('/fcd/') &&
+    !pathname.startsWith('/update/') &&
     !isSocialImagePath(pathname) &&
     !isFileRequest(pathname)
   )
@@ -99,26 +107,33 @@ const handleLocaleRedirects = (request: Request) => {
     return undefined
   }
 
-  if (pathname !== '/' && pathname.endsWith('/')) {
-    return redirectTo(request, pathname.replace(/\/+$/, ''), 308)
-  }
-
   const locale = getPathLocale(pathname)
+  let canonicalPathname = pathname
+  if (canonicalPathname !== '/' && canonicalPathname.endsWith('/')) {
+    canonicalPathname = canonicalPathname.replace(/\/+$/, '')
+  }
   if (locale && isDefaultLocale(locale)) {
-    return redirectTo(request, stripLocalePrefix(pathname), 308)
+    canonicalPathname = stripLocalePrefix(canonicalPathname)
   }
 
-  const firstSegment = pathname.split('/').find(Boolean)
-  const secondSegment = pathname.split('/').filter(Boolean)[1]
+  if (canonicalPathname !== pathname) {
+    return redirectTo(request, canonicalPathname, 308)
+  }
+
+  const pathSegments = pathname.split('/').filter(Boolean)
+  const firstSegment = pathSegments[0]
+  const secondSegment = pathSegments[1]
   const knownUnprefixedPage =
     firstSegment === 'download' || firstSegment === 'explore'
+  const localeShapedSegment =
+    !!firstSegment && /^[a-z]{2}(?:-[A-Za-z]+)?$/.test(firstSegment)
   const knownLocalizedPage =
     firstSegment &&
     !knownUnprefixedPage &&
     !isSupportedLocale(firstSegment) &&
-    (secondSegment === undefined ||
-      secondSegment === 'download' ||
-      secondSegment === 'explore')
+    (pathSegments.length === 1 ||
+      (localeShapedSegment &&
+        (secondSegment === 'download' || secondSegment === 'explore')))
   if (knownLocalizedPage) {
     return new Response('', { status: 404 })
   }
@@ -230,6 +245,10 @@ const worker = {
     let response: Response | undefined
     if (isMonitoringPath(pathname)) {
       response = handleMonitoringStub(request)
+    }
+
+    if (isProxyRootPath(pathname)) {
+      response = new Response('', { status: 404 })
     }
 
     response ??= handleLocaleRedirects(request)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -88,6 +88,7 @@ const redirectTo = (request: Request, pathname: string, status: 307 | 308) => {
     headers.set('Cache-Control', 'no-store')
     headers.set('Vary', 'Cookie, Accept-Language')
   }
+  headers.set('Content-Type', 'text/plain; charset=utf-8')
   return new Response('', {
     headers: {
       ...Object.fromEntries(headers),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -53,7 +53,10 @@ const isSocialImagePath = (pathname: string) => {
 }
 
 const isProxyRootPath = (pathname: string) => {
-  return pathname === '/dist' || pathname === '/fcd' || pathname === '/update'
+  const normalized = pathname === '/' ? pathname : pathname.replace(/\/+$/, '')
+  return (
+    normalized === '/dist' || normalized === '/fcd' || normalized === '/update'
+  )
 }
 
 const isPageRequest = (request: Request) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
+import { fileURLToPath } from 'node:url'
+
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     include: ['src/**/*.test.ts'],
   },


### PR DESCRIPTION
Closes #488

## Summary

- Adds TanStack localized page routes for `/`, `/download`, `/explore`, and non-default locale-prefixed variants.
- Adds Worker-level canonicalization for trailing slashes, `/ja/*` default-locale prefixes, locale preference redirects, and unsupported locale-like paths.
- Keeps API/proxy/static/social image routes out of locale negotiation.
- Adds i18next-backed TanStack page data helpers and explicit `NEXT_LOCALE` / `Accept-Language` routing helpers.
- Adds localized page tests for default locale, non-default locale content, redirects, unsupported locales, and bypassed API/asset routes.

## Validation

- `pnpm run lint:next` (passes with existing middleware warning)
- `pnpm run typecheck`
- `pnpm run test:unit`
- `pnpm run check:tanstack-imports`
- `pnpm run test:e2e:tanstack`
- `pnpm run test:e2e:next`

## Notes

- The default locale remains `ja` and canonical default-locale page URLs are unprefixed.
- Non-default preferred locale redirects use `307`, `Cache-Control: no-store`, and preserve query strings.
- Canonical trailing-slash and `/ja/*` redirects use `308`.
- `Accept-Language` parsing honors `q` values and maps Chinese script/region tags to `zh-Hans`/`zh-Hant`.
