### PR TITLE
Add TanStack request-aware download pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev:tanstack": "vite dev --config vite.config.ts --host 127.0.0.1 --port 3002",
     "build:tanstack": "vite build --config vite.config.ts",
     "preview:tanstack": "vite preview --config vite.config.ts --host 127.0.0.1 --port 3002",
-    "test:e2e:tanstack": "vite build --config vite.config.ts && playwright test --config=playwright.tanstack.config.ts",
+    "test:e2e:tanstack": "node scripts/test-tanstack-e2e.mjs",
     "cf-typegen:tanstack": "wrangler types --config wrangler.tanstack.jsonc --env-interface TanStackCloudflareEnv cloudflare-tanstack-env.d.ts",
     "start": "next start",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",

--- a/scripts/test-tanstack-e2e.mjs
+++ b/scripts/test-tanstack-e2e.mjs
@@ -1,0 +1,18 @@
+import { execa } from 'execa'
+
+const env = {
+  ...process.env,
+  TANSTACK_TEST_POI_VERSIONS: JSON.stringify({
+    betaVersion: 'v10.10.0-beta.1',
+    version: 'v10.9.2',
+  }),
+}
+
+await execa('vite', ['build', '--config', 'vite.config.ts'], {
+  env,
+  stdio: 'inherit',
+})
+await execa('playwright', ['test', '--config=playwright.tanstack.config.ts'], {
+  env,
+  stdio: 'inherit',
+})

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -11,7 +11,9 @@ test('serves default locale content at unprefixed root', async ({ page }) => {
   await page.goto('/')
 
   await expect(page.getByText(/拡張可能/)).toBeVisible()
-  await expect(page.getByRole('link', { name: 'ダウンロード' })).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: 'ダウンロードオプション' }),
+  ).toBeVisible()
 })
 
 test('redirects locale preference to non-default locale path', async ({
@@ -96,21 +98,135 @@ test('serves localized non-default content', async ({ page }) => {
   await expect(
     page.getByText('Scalable KanColle browser and tool.'),
   ).toBeVisible()
-  await expect(page.getByRole('link', { name: 'Download' })).toBeVisible()
-  await expect(page.getByText('New')).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: 'Download options' }),
+  ).toBeVisible()
+  await expect(page.getByText('New', { exact: true })).toBeVisible()
 })
 
 test('serves localized download and explore pages', async ({ page }) => {
   await page.goto('/en/download')
   await expect(page.getByRole('heading', { name: 'Download' })).toBeVisible()
-  await expect(
-    page.getByRole('heading', { name: 'Old versions' }),
-  ).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Others' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'Nightly builds' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'Source code' })).toBeVisible()
 
   await page.goto('/en/explore')
   await expect(page.locator('main')).toContainText('poi')
+})
+
+test('renders desktop request-aware download links', async ({ browser }) => {
+  const context = await browser.newContext({
+    baseURL: 'http://127.0.0.1:3002',
+    extraHTTPHeaders: {
+      'Sec-CH-UA-Arch': '"x86"',
+      'Sec-CH-UA-Bitness': '"64"',
+      'Sec-CH-UA-Mobile': '?0',
+      'Sec-CH-UA-Platform': '"Windows"',
+    },
+    userAgent:
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+      '(KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',
+  })
+  const page = await context.newPage()
+
+  await page.goto('/en')
+  await expect(
+    page.getByRole('link', { name: /Download v10\.9\.2/ }),
+  ).toHaveAttribute('href', '/dist/poi-setup-10.9.2.exe')
+  await expect(
+    page.getByRole('link', { name: /Download v10\.10\.0-beta\.1/ }),
+  ).toHaveAttribute('href', '/dist/poi-setup-10.10.0-beta.1.exe')
+  await expect(page.getByText('Sighted by skilled lookouts:')).toBeVisible()
+  await expect(page.getByText('Windows')).toBeVisible()
+  await expect(page.getByText('64-bit')).toBeVisible()
+
+  await page.getByRole('link', { name: 'Download options' }).click()
+  await expect(page).toHaveURL('http://127.0.0.1:3002/en/download')
+  await expect(
+    page.getByRole('link', { name: /Download v10\.9\.2/ }),
+  ).toHaveAttribute('href', '/dist/poi-setup-10.9.2.exe')
+  await expect(page.getByText('Operating system')).toBeVisible()
+  const platformButtons = page.getByRole('button')
+  await expect(platformButtons).toHaveCount(2)
+  await platformButtons.first().click()
+  const linuxItem = page.getByRole('menuitem', { name: 'Linux' })
+  await expect(linuxItem).toBeVisible()
+  await linuxItem.click()
+  await expect(platformButtons.nth(1)).toBeVisible()
+  await platformButtons.nth(1).click()
+  const portableItem = page.getByRole('menuitem', { name: '64-bit portable' })
+  await expect(portableItem).toBeVisible()
+  await portableItem.click()
+  await expect(
+    page.getByRole('link', { name: /Download v10\.9\.2/ }),
+  ).toHaveAttribute('href', '/dist/poi-10.9.2.7z')
+
+  await context.close()
+})
+
+test('renders mobile request-aware hint without download links', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    baseURL: 'http://127.0.0.1:3002',
+    extraHTTPHeaders: {
+      'Sec-CH-UA-Mobile': '?1',
+      'Sec-CH-UA-Platform': '"iOS"',
+    },
+    isMobile: true,
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) ' +
+      'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  })
+  const page = await context.newPage()
+
+  await page.goto('/en')
+  await expect(
+    page.getByText('poi is designed for desktop devices'),
+  ).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: /Download v10\.9\.2/ }),
+  ).toHaveCount(0)
+
+  await page.goto('/en/download')
+  await expect(
+    page.getByText('poi is designed for desktop devices'),
+  ).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: /Download v10\.9\.2/ }),
+  ).toHaveCount(0)
+
+  await context.close()
+})
+
+test('does not leak SSR platform state between download requests', async ({
+  request,
+}) => {
+  const windowsResponse = await request.get('/en/download', {
+    headers: {
+      'Sec-CH-UA-Arch': '"x86"',
+      'Sec-CH-UA-Bitness': '"64"',
+      'Sec-CH-UA-Mobile': '?0',
+      'Sec-CH-UA-Platform': '"Windows"',
+      'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+    },
+  })
+  const linuxArmResponse = await request.get('/en/download', {
+    headers: {
+      'Sec-CH-UA-Arch': '"arm"',
+      'Sec-CH-UA-Mobile': '?0',
+      'Sec-CH-UA-Platform': '"Linux"',
+      'User-Agent': 'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36',
+    },
+  })
+
+  const windowsHtml = await windowsResponse.text()
+  const linuxArmHtml = await linuxArmResponse.text()
+  expect(windowsHtml).toContain('/dist/poi-setup-10.9.2.exe')
+  expect(linuxArmHtml).toContain('/dist/poi-10.9.2-arm64.7z')
+  expect(linuxArmHtml).not.toContain('/dist/poi-setup-10.9.2.exe')
 })
 
 test('rejects unsupported locale-like prefixes', async ({ request }) => {

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -153,8 +153,12 @@ test('renders desktop request-aware download links', async ({ browser }) => {
   const linuxItem = page.getByRole('menuitem', { name: 'Linux' })
   await expect(linuxItem).toBeVisible()
   await linuxItem.click()
-  await expect(platformButtons.nth(1)).toBeVisible()
-  await platformButtons.nth(1).click()
+  const platformButton = page.getByRole('button', { name: 'Platform' })
+  await expect(platformButton).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: /Download v10\.9\.2/ }),
+  ).toHaveCount(0)
+  await platformButton.click()
   const portableItem = page.getByRole('menuitem', { name: '64-bit portable' })
   await expect(portableItem).toBeVisible()
   await portableItem.click()

--- a/specs-tanstack/scaffold.spec.ts
+++ b/specs-tanstack/scaffold.spec.ts
@@ -13,7 +13,9 @@ test('renders the isolated TanStack preview route', async ({ page }) => {
 
   await expect(page.getByRole('heading', { name: 'poi' })).toBeVisible()
   await expect(page.getByText(/拡張可能/)).toBeVisible()
-  await expect(page.getByRole('link', { name: 'ダウンロード' })).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: 'ダウンロードオプション' }),
+  ).toBeVisible()
   await expect(page.locator('body')).toHaveCSS(
     'background-color',
     'rgb(255, 255, 255)',

--- a/src/components/download/download-links.tsx
+++ b/src/components/download/download-links.tsx
@@ -28,13 +28,12 @@ export const DownloadLinks = ({ labels, poiVersions }: DownloadLinksProps) => {
   const stableURL = target ? getDownloadLink(poiVersions.version, target) : ''
   const betaURL = target ? getDownloadLink(poiVersions.betaVersion, target) : ''
 
+  if (!target) {
+    return null
+  }
+
   return (
-    <div
-      aria-hidden={!os || !spec}
-      className={cn('not-prose my-8 flex gap-8', {
-        'opacity-0': !os || !spec,
-      })}
-    >
+    <div className={cn('not-prose my-8 flex gap-8')}>
       <Button className="h-fit flex-col" asChild disabled={!stableURL}>
         <a href={stableURL}>
           <span>{labels.stable}</span>

--- a/src/components/download/download-links.tsx
+++ b/src/components/download/download-links.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { compare } from 'compare-versions'
+import { useAtomValue } from 'jotai'
+
+import { osAtom, specAtom } from './store'
+
+import { Button } from '~/components/ui/button'
+import { type PoiVersions } from '~/lib/fetch-poi-versions'
+import { getDownloadLink, platformToTarget, type Target } from '~/lib/target'
+import { cn } from '~/lib/utils'
+
+interface DownloadLinksProps {
+  labels: {
+    beta: string
+    betaHint: string
+    stable: string
+    stableHint: string
+  }
+  poiVersions: PoiVersions
+}
+
+export const DownloadLinks = ({ labels, poiVersions }: DownloadLinksProps) => {
+  const os = useAtomValue(osAtom)
+  const spec = useAtomValue(specAtom)
+  const target: Target | undefined = platformToTarget[os!]?.[spec!]
+
+  const stableURL = target ? getDownloadLink(poiVersions.version, target) : ''
+  const betaURL = target ? getDownloadLink(poiVersions.betaVersion, target) : ''
+
+  return (
+    <div
+      aria-hidden={!os || !spec}
+      className={cn('not-prose my-8 flex gap-8', {
+        'opacity-0': !os || !spec,
+      })}
+    >
+      <Button className="h-fit flex-col" asChild disabled={!stableURL}>
+        <a href={stableURL}>
+          <span>{labels.stable}</span>
+          <span>{labels.stableHint}</span>
+        </a>
+      </Button>
+      {compare(poiVersions.version, poiVersions.betaVersion, '<') && (
+        <Button
+          variant="secondary"
+          className="h-fit flex-col"
+          asChild
+          disabled={!betaURL}
+        >
+          <a href={betaURL}>
+            <span>{labels.beta}</span>
+            <span>{labels.betaHint}</span>
+          </a>
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/components/download/platform-select.tsx
+++ b/src/components/download/platform-select.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useAtom } from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
+import { ChevronsUpDown } from 'lucide-react'
+import { useMemo } from 'react'
+
+import { osAtom, specAtom } from './store'
+
+import { Button } from '~/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '~/components/ui/dropdown-menu'
+import { OS, type PlatformSpec, platformToTarget } from '~/lib/target'
+
+interface PlatformSelectProps {
+  initialOS?: OS
+  initialSpec?: PlatformSpec
+  labels: {
+    operatingSystem: string
+    os: Record<OS, string>
+    platform: string
+    spec: Record<PlatformSpec, string>
+  }
+}
+
+export const PlatformSelect = ({
+  initialOS,
+  initialSpec,
+  labels,
+}: PlatformSelectProps) => {
+  useHydrateAtoms([
+    [osAtom, initialOS],
+    [specAtom, initialSpec],
+  ])
+
+  const [os, setOS] = useAtom(osAtom)
+  const [spec, setSpec] = useAtom(specAtom)
+
+  const osOptions = useMemo(() => {
+    return Object.values(OS).map((os) => ({ label: labels.os[os], value: os }))
+  }, [labels.os])
+
+  const specOptions = useMemo(() => {
+    return Object.keys(platformToTarget[os!] ?? {}).map((spec) => ({
+      label: labels.spec[spec as PlatformSpec],
+      value: spec,
+    }))
+  }, [labels.spec, os])
+
+  return (
+    <div className="grid w-fit grid-cols-2 gap-4">
+      <div>{labels.operatingSystem}</div>
+      <div>
+        <ComboBox
+          value={os as string}
+          options={osOptions}
+          onChange={(value) => {
+            setOS(value as OS)
+            setSpec(undefined)
+          }}
+        />
+      </div>
+      <div>{labels.platform}</div>
+      <div>
+        <ComboBox
+          value={spec as string}
+          options={specOptions}
+          onChange={(value) => {
+            setSpec(value as PlatformSpec)
+          }}
+          disabled={!os}
+        />
+      </div>
+    </div>
+  )
+}
+
+interface ComboBoxProps {
+  value: string
+  options: { label: string; value: string }[]
+  onChange: (value: string) => void
+  disabled?: boolean
+}
+
+const ComboBox = ({ options, value, onChange, disabled }: ComboBoxProps) => {
+  const currentLabel =
+    options.find((option) => option.value === value)?.label ?? ''
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" disabled={disabled} className="w-56">
+          <span className="grow text-end">{currentLabel}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        {options.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            onSelect={() => onChange(option.value)}
+          >
+            {option.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/components/download/platform-select.tsx
+++ b/src/components/download/platform-select.tsx
@@ -56,6 +56,7 @@ export const PlatformSelect = ({
       <div>{labels.operatingSystem}</div>
       <div>
         <ComboBox
+          placeholder={labels.operatingSystem}
           value={os as string}
           options={osOptions}
           onChange={(value) => {
@@ -67,6 +68,7 @@ export const PlatformSelect = ({
       <div>{labels.platform}</div>
       <div>
         <ComboBox
+          placeholder={labels.platform}
           value={spec as string}
           options={specOptions}
           onChange={(value) => {
@@ -84,15 +86,28 @@ interface ComboBoxProps {
   options: { label: string; value: string }[]
   onChange: (value: string) => void
   disabled?: boolean
+  placeholder: string
 }
 
-const ComboBox = ({ options, value, onChange, disabled }: ComboBoxProps) => {
+const ComboBox = ({
+  disabled,
+  onChange,
+  options,
+  placeholder,
+  value,
+}: ComboBoxProps) => {
   const currentLabel =
-    options.find((option) => option.value === value)?.label ?? ''
+    options.find((option) => option.value === value)?.label ?? placeholder
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" disabled={disabled} className="w-56">
+        <Button
+          variant="outline"
+          disabled={disabled}
+          className="w-56"
+          aria-label={currentLabel}
+          title={currentLabel}
+        >
           <span className="grow text-end">{currentLabel}</span>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>

--- a/src/components/download/store.ts
+++ b/src/components/download/store.ts
@@ -1,0 +1,7 @@
+import { atom } from 'jotai'
+
+import { type OS, type PlatformSpec } from '~/lib/target'
+
+export const osAtom = atom<OS>()
+
+export const specAtom = atom<PlatformSpec>()

--- a/src/lib/tanstack-page-data.ts
+++ b/src/lib/tanstack-page-data.ts
@@ -57,7 +57,13 @@ const loadPoiVersions = async (env?: ServerContext['env']) => {
   const fixture =
     env?.TANSTACK_TEST_POI_VERSIONS ?? process.env.TANSTACK_TEST_POI_VERSIONS
   if (fixture) {
-    return poiVersionsSchema.parse(JSON.parse(fixture) as unknown)
+    try {
+      return poiVersionsSchema.parse(JSON.parse(fixture) as unknown)
+    } catch (error) {
+      throw new Error('Invalid TANSTACK_TEST_POI_VERSIONS fixture JSON', {
+        cause: error,
+      })
+    }
   }
 
   return await fetchPoiVersions()
@@ -137,7 +143,9 @@ export const loadRequestAwarePageData = async (
   const serverContext = normalizeServerContext(context)
   const headers = serverContext?.requestHeaders
     ? new Headers(serverContext.requestHeaders)
-    : getCurrentRequestHeaders()
+    : typeof document === 'undefined'
+      ? getCurrentRequestHeaders()
+      : new Headers()
   const [{ t }, poiVersions, platform] = await Promise.all([
     initTranslations(supportedLocale, ['common']),
     loadPoiVersions(serverContext?.env),

--- a/src/lib/tanstack-page-data.ts
+++ b/src/lib/tanstack-page-data.ts
@@ -1,3 +1,7 @@
+import { createServerOnlyFn } from '@tanstack/react-start'
+import { getRequestHeaders } from '@tanstack/react-start/server'
+import { compare } from 'compare-versions'
+import type { TFunction } from 'i18next'
 import sanitize from 'rehype-sanitize'
 import stringify from 'rehype-stringify'
 import { remark } from 'remark'
@@ -5,10 +9,23 @@ import rehype from 'remark-rehype'
 
 import { initTranslations } from '~/i18n'
 import {
+  fetchPoiVersions,
+  poiVersionsSchema,
+  type PoiVersions,
+} from '~/lib/fetch-poi-versions'
+import {
   defaultLocale,
   isSupportedLocale,
   type SupportedLocale,
 } from '~/lib/i18n-routing'
+import {
+  detectRequestPlatform,
+  getDownloadLink,
+  OS,
+  PlatformSpec,
+  type RequestPlatformResult,
+} from '~/lib/target'
+import { type TanStackRouterContext } from '~/routes/__root'
 
 const exploreContentByLocale = import.meta.glob<string>(
   '../contents/explore/*.md',
@@ -20,6 +37,79 @@ const exploreContentByLocale = import.meta.glob<string>(
 )
 
 const exploreHtmlByLocale = new Map<SupportedLocale, string>()
+
+type ServerContext = NonNullable<TanStackRouterContext['serverContext']>
+type RequestAwareContext = ServerContext | TanStackRouterContext
+
+const getCurrentRequestHeaders = createServerOnlyFn(
+  () => new Headers(getRequestHeaders()),
+)
+
+const normalizeServerContext = (
+  context?: RequestAwareContext,
+): ServerContext | undefined => {
+  return context && 'serverContext' in context && context.serverContext
+    ? context.serverContext
+    : context
+}
+
+const loadPoiVersions = async (env?: ServerContext['env']) => {
+  const fixture =
+    env?.TANSTACK_TEST_POI_VERSIONS ?? process.env.TANSTACK_TEST_POI_VERSIONS
+  if (fixture) {
+    return poiVersionsSchema.parse(JSON.parse(fixture) as unknown)
+  }
+
+  return await fetchPoiVersions()
+}
+
+const buildCommonTranslations = (t: TFunction<'common'>) => ({
+  betaHint: t('beta-hint'),
+  description: t('description'),
+  download: t('Download'),
+  downloadOptions: t('Download options'),
+  explore: t('Explore'),
+  httpsUpdateSupported: t('HTTPS game update supported!'),
+  language: t('language'),
+  mobileHint: t('mobile-hint'),
+  name: t('name'),
+  newLabel: t('New'),
+  nightlyBuilds: t('Nightly builds'),
+  oldVersions: t('Old versions'),
+  operatingSystem: t('Operating system'),
+  options: t('Options'),
+  others: t('Others'),
+  platformLabel: t('Platform'),
+  sightedBySkilledLookouts: t('Sighted by skilled lookouts:'),
+  sourceCode: t('Source code'),
+  stableHint: t('stable-hint'),
+  title: t('KanColle Browser'),
+})
+
+const buildPlatformLabels = (t: TFunction<'common'>) => ({
+  os: Object.fromEntries(Object.values(OS).map((os) => [os, t(os)])) as Record<
+    OS,
+    string
+  >,
+  spec: Object.fromEntries(
+    Object.values(PlatformSpec).map((spec) => [spec, t(spec)]),
+  ) as Record<PlatformSpec, string>,
+})
+
+const buildDownloadData = (
+  t: TFunction<'common'>,
+  poiVersions: PoiVersions,
+  platform: RequestPlatformResult,
+) => ({
+  betaDownloadLabel: t('download', { version: poiVersions.betaVersion }),
+  betaUrl: getDownloadLink(poiVersions.betaVersion, platform.target),
+  platform,
+  platformLabels: buildPlatformLabels(t),
+  poiVersions,
+  showBeta: compare(poiVersions.version, poiVersions.betaVersion, '<'),
+  stableDownloadLabel: t('download', { version: poiVersions.version }),
+  stableUrl: getDownloadLink(poiVersions.version, platform.target),
+})
 
 export const requireSupportedLocale = (locale: string): SupportedLocale => {
   if (!isSupportedLocale(locale)) {
@@ -36,20 +126,27 @@ export const loadCommonTranslations = async (
 ) => {
   const supportedLocale = requireSupportedLocale(locale)
   const { t } = await initTranslations(supportedLocale, ['common'])
+  return buildCommonTranslations(t)
+}
+
+export const loadRequestAwarePageData = async (
+  locale: string = defaultLocale,
+  context?: RequestAwareContext,
+) => {
+  const supportedLocale = requireSupportedLocale(locale)
+  const serverContext = normalizeServerContext(context)
+  const headers = serverContext?.requestHeaders
+    ? new Headers(serverContext.requestHeaders)
+    : getCurrentRequestHeaders()
+  const [{ t }, poiVersions, platform] = await Promise.all([
+    initTranslations(supportedLocale, ['common']),
+    loadPoiVersions(serverContext?.env),
+    detectRequestPlatform(headers),
+  ])
+
   return {
-    description: t('description'),
-    download: t('Download'),
-    downloadOptions: t('Download options'),
-    explore: t('Explore'),
-    httpsUpdateSupported: t('HTTPS game update supported!'),
-    language: t('language'),
-    mobileHint: t('mobile-hint'),
-    name: t('name'),
-    newLabel: t('New'),
-    nightlyBuilds: t('Nightly builds'),
-    oldVersions: t('Old versions'),
-    sourceCode: t('Source code'),
-    title: t('KanColle Browser'),
+    ...buildCommonTranslations(t),
+    ...buildDownloadData(t, poiVersions, platform),
   }
 }
 

--- a/src/lib/target.test.ts
+++ b/src/lib/target.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { detectTargetFromRequest, OS, PlatformSpec, Target } from './target'
+import {
+  detectTargetFromRequest,
+  isMobileDevice,
+  OS,
+  parseUA,
+  PlatformSpec,
+  Target,
+} from './target'
 
 describe('detectTargetFromRequest', () => {
   it('maps Windows ARM client hints to the Windows ARM target', async () => {
@@ -18,6 +25,21 @@ describe('detectTargetFromRequest', () => {
       os: OS.windows,
       spec: PlatformSpec.ARM,
       target: Target.winArm,
+    })
+  })
+
+  describe('isMobileDevice', () => {
+    it('classifies wearable user agents as mobile devices', async () => {
+      const headers = new Headers({
+        'User-Agent':
+          'Mozilla/5.0 (Linux; Android 13; Google Pixel Watch Build/TWD9.230205.001) ' +
+          'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+      })
+
+      await expect(parseUA(headers)).resolves.toMatchObject({
+        device: { type: 'wearable' },
+      })
+      await expect(isMobileDevice(headers)).resolves.toBe(true)
     })
   })
 

--- a/src/lib/target.test.ts
+++ b/src/lib/target.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { detectTargetFromRequest, OS, PlatformSpec, Target } from './target'
+
+describe('detectTargetFromRequest', () => {
+  it('maps Windows ARM client hints to the Windows ARM target', async () => {
+    await expect(
+      detectTargetFromRequest(
+        new Headers({
+          'Sec-CH-UA-Arch': '"arm"',
+          'Sec-CH-UA-Mobile': '?0',
+          'Sec-CH-UA-Platform': '"Windows"',
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; ARM64) AppleWebKit/537.36',
+        }),
+      ),
+    ).resolves.toEqual({
+      os: OS.windows,
+      spec: PlatformSpec.ARM,
+      target: Target.winArm,
+    })
+  })
+
+  it('maps generic Linux ARM to an available Linux ARM platform spec', async () => {
+    await expect(
+      detectTargetFromRequest(
+        new Headers({
+          'Sec-CH-UA-Arch': '"arm"',
+          'Sec-CH-UA-Mobile': '?0',
+          'Sec-CH-UA-Platform': '"Linux"',
+          'User-Agent': 'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36',
+        }),
+      ),
+    ).resolves.toEqual({
+      os: OS.linux,
+      spec: PlatformSpec.ARMPortable,
+      target: Target.linuxArm,
+    })
+  })
+
+  it('maps Fedora ARM to an available Linux ARM platform spec', async () => {
+    await expect(
+      detectTargetFromRequest(
+        new Headers({
+          'Sec-CH-UA-Arch': '"arm"',
+          'Sec-CH-UA-Mobile': '?0',
+          'Sec-CH-UA-Platform': '"Linux"',
+          'User-Agent':
+            'Mozilla/5.0 (X11; Fedora; Linux aarch64) AppleWebKit/537.36',
+        }),
+      ),
+    ).resolves.toEqual({
+      os: OS.linux,
+      spec: PlatformSpec.ARMPortable,
+      target: Target.linuxArm,
+    })
+  })
+})

--- a/src/lib/target.ts
+++ b/src/lib/target.ts
@@ -123,7 +123,7 @@ const isMobileUA = (ua: Awaited<ReturnType<typeof parseUA>>) => {
     'tablet',
     'console',
     'smarttv',
-    'wearbale',
+    'wearable',
     'embedded',
   ].includes(ua.device.type!)
 }

--- a/src/lib/target.ts
+++ b/src/lib/target.ts
@@ -103,18 +103,21 @@ export const getDownloadLink = (
   }
 }
 
-interface DetectionResult {
+export interface DetectionResult {
   os: OS
   spec: PlatformSpec
   target: Target
+}
+
+export interface RequestPlatformResult extends DetectionResult {
+  isMobile: boolean
 }
 
 export const parseUA = async (headers: Headers) => {
   return UAParser(Object.fromEntries(headers)).withClientHints()
 }
 
-export const isMobileDevice = async (headers: Headers) => {
-  const ua = await parseUA(headers)
+const isMobileUA = (ua: Awaited<ReturnType<typeof parseUA>>) => {
   return [
     'mobile',
     'tablet',
@@ -125,13 +128,21 @@ export const isMobileDevice = async (headers: Headers) => {
   ].includes(ua.device.type!)
 }
 
-export const detectTargetFromRequest = async (
-  headers: Headers,
-): Promise<DetectionResult> => {
-  const { os, cpu } = await parseUA(headers)
+export const isMobileDevice = async (headers: Headers) => {
+  return isMobileUA(await parseUA(headers))
+}
+
+const detectTargetFromUA = (
+  ua: Awaited<ReturnType<typeof parseUA>>,
+): DetectionResult => {
+  const { os, cpu } = ua
   if (os.name === 'Linux') {
     if (cpu.architecture === 'arm64' || cpu.architecture === 'arm') {
-      return { os: OS.linux, spec: PlatformSpec.ARM, target: Target.linuxArm }
+      return {
+        os: OS.linux,
+        spec: PlatformSpec.ARMPortable,
+        target: Target.linuxArm,
+      }
     }
     return {
       os: OS.linux,
@@ -139,6 +150,7 @@ export const detectTargetFromRequest = async (
       target: Target.linux,
     }
   }
+
   if (os.name === 'Debian' || os.name === 'Ubuntu') {
     if (cpu.architecture === 'arm64' || cpu.architecture === 'arm') {
       return {
@@ -147,6 +159,7 @@ export const detectTargetFromRequest = async (
         target: Target.linuxDebArm,
       }
     }
+
     return {
       os: OS.linux,
       spec: PlatformSpec.X64DEB,
@@ -154,6 +167,13 @@ export const detectTargetFromRequest = async (
     }
   }
   if (os.name === 'CentOS' || os.name === 'Fedora') {
+    if (cpu.architecture === 'arm64' || cpu.architecture === 'arm') {
+      return {
+        os: OS.linux,
+        spec: PlatformSpec.ARMPortable,
+        target: Target.linuxArm,
+      }
+    }
     return {
       os: OS.linux,
       spec: PlatformSpec.X64RPM,
@@ -175,6 +195,13 @@ export const detectTargetFromRequest = async (
     }
   }
   if (os.name === 'Windows') {
+    if (cpu.architecture === 'arm64' || cpu.architecture === 'arm') {
+      return {
+        os: OS.windows,
+        spec: PlatformSpec.ARM,
+        target: Target.winArm,
+      }
+    }
     if (cpu.architecture === 'ia64' || cpu.architecture === 'amd64') {
       return {
         os: OS.windows,
@@ -192,5 +219,21 @@ export const detectTargetFromRequest = async (
     os: OS.linux,
     spec: PlatformSpec.X64Portable,
     target: Target.linux,
+  }
+}
+
+export const detectTargetFromRequest = async (
+  headers: Headers,
+): Promise<DetectionResult> => {
+  return detectTargetFromUA(await parseUA(headers))
+}
+
+export const detectRequestPlatform = async (
+  headers: Headers,
+): Promise<RequestPlatformResult> => {
+  const ua = await parseUA(headers)
+  return {
+    ...detectTargetFromUA(ua),
+    isMobile: isMobileUA(ua),
   }
 }

--- a/src/routes/$locale.download.tsx
+++ b/src/routes/$locale.download.tsx
@@ -1,14 +1,17 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+import { DownloadLinks } from '~/components/download/download-links'
+import { PlatformSelect } from '~/components/download/platform-select'
+import { Transition } from '~/components/transition'
 import { Button } from '~/components/ui/button'
 import {
-  loadCommonTranslations,
+  loadRequestAwarePageData,
   requireSupportedLocale,
 } from '~/lib/tanstack-page-data'
 
 export const Route = createFileRoute('/$locale/download')({
-  loader: ({ params }) =>
-    loadCommonTranslations(requireSupportedLocale(params.locale)),
+  loader: ({ context, params }) =>
+    loadRequestAwarePageData(requireSupportedLocale(params.locale), context),
   head: ({ loaderData }) => ({
     meta: [
       {
@@ -22,41 +25,70 @@ export const Route = createFileRoute('/$locale/download')({
 })
 
 function LocalizedDownloadPage() {
-  const t = Route.useLoaderData()
+  const data = Route.useLoaderData()
   return (
     <main className="prose mx-auto flex min-h-screen max-w-[960px] flex-col justify-center p-4 dark:prose-invert">
-      <h1>{t.download}</h1>
-      <p>{t.mobileHint}</p>
-      <h2>{t.oldVersions}</h2>
-      <div>
-        <Button variant="link" asChild>
-          <a
-            href="https://registry.npmmirror.com/binary.html?path=poi/"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {t.oldVersions}
-          </a>
-        </Button>
-        <Button variant="link" asChild>
-          <a
-            href="https://nightly.poi.moe/"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {t.nightlyBuilds}
-          </a>
-        </Button>
-        <Button variant="link" asChild>
-          <a
-            href="https://github.com/poooi/poi"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {t.sourceCode}
-          </a>
-        </Button>
-      </div>
+      <Transition>
+        <h1>{data.download}</h1>
+        {data.platform.isMobile ? (
+          <p>{data.mobileHint}</p>
+        ) : (
+          <section>
+            <PlatformSelect
+              initialOS={data.platform.os}
+              initialSpec={data.platform.spec}
+              labels={{
+                operatingSystem: data.operatingSystem,
+                os: data.platformLabels.os,
+                platform: data.platformLabel,
+                spec: data.platformLabels.spec,
+              }}
+            />
+            <DownloadLinks
+              labels={{
+                beta: data.betaDownloadLabel,
+                betaHint: data.betaHint,
+                stable: data.stableDownloadLabel,
+                stableHint: data.stableHint,
+              }}
+              poiVersions={data.poiVersions}
+            />
+          </section>
+        )}
+        <h2>{data.others}</h2>
+        <section className="flex w-fit flex-col items-center">
+          <div>
+            <Button variant="link" asChild>
+              <a
+                href="https://registry.npmmirror.com/binary.html?path=poi/"
+                rel="noopener noreferrer"
+                target="_blank"
+                data-testid="old-versions"
+              >
+                {data.oldVersions}
+              </a>
+            </Button>
+            <Button variant="link" asChild>
+              <a
+                href="https://nightly.poi.moe/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {data.nightlyBuilds}
+              </a>
+            </Button>
+            <Button variant="link" asChild>
+              <a
+                href="https://github.com/poooi/poi"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {data.sourceCode}
+              </a>
+            </Button>
+          </div>
+        </section>
+      </Transition>
     </main>
   )
 }

--- a/src/routes/$locale.index.tsx
+++ b/src/routes/$locale.index.tsx
@@ -1,15 +1,17 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+/* eslint-disable @next/next/no-html-link-for-pages */
+import { createFileRoute } from '@tanstack/react-router'
 
+import { Transition } from '~/components/transition'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
 import {
-  loadCommonTranslations,
+  loadRequestAwarePageData,
   requireSupportedLocale,
 } from '~/lib/tanstack-page-data'
 
 export const Route = createFileRoute('/$locale/')({
-  loader: ({ params }) =>
-    loadCommonTranslations(requireSupportedLocale(params.locale)),
+  loader: ({ context, params }) =>
+    loadRequestAwarePageData(requireSupportedLocale(params.locale), context),
   head: ({ loaderData }) => ({
     meta: [{ title: `poi | ${loaderData?.title ?? 'KanColle Browser'}` }],
   }),
@@ -17,30 +19,63 @@ export const Route = createFileRoute('/$locale/')({
 })
 
 function LocalizedHomePage() {
-  const t = Route.useLoaderData()
+  const data = Route.useLoaderData()
   const { locale } = Route.useParams()
   return (
     <main className="mx-auto flex min-h-screen max-w-[960px] flex-col items-start justify-center gap-6 bg-background p-4 text-foreground">
-      <h1 className="text-7xl leading-loose">{t.name}</h1>
-      <p className="text-2xl">{t.description}</p>
-      <div className="flex gap-4">
-        <Button asChild>
-          <Link to="/$locale/download" params={{ locale }}>
-            {t.download}
-          </Link>
-        </Button>
-        <Button variant="secondary" asChild>
-          <Link to="/$locale/explore" params={{ locale }}>
-            {t.explore}
-          </Link>
-        </Button>
-      </div>
-      <div className="flex items-center gap-2">
-        <Badge variant="outline" className="bg-green-500 text-white">
-          {t.newLabel}
-        </Badge>
-        <span>{t.httpsUpdateSupported}</span>
-      </div>
+      <Transition className="w-full">
+        <h1 className="text-7xl leading-loose">{data.name}</h1>
+        <p className="text-2xl">{data.description}</p>
+        {data.platform.isMobile ? (
+          <p className="mt-4">{data.mobileHint}</p>
+        ) : (
+          <>
+            <div className="my-8">
+              <div className="flex gap-8">
+                <Button className="h-fit flex-col" asChild>
+                  <a href={data.stableUrl}>
+                    <span>{data.stableDownloadLabel}</span>
+                    <span>{data.stableHint}</span>
+                  </a>
+                </Button>
+                {data.showBeta && (
+                  <Button
+                    variant="secondary"
+                    className="h-fit flex-col"
+                    asChild
+                  >
+                    <a href={data.betaUrl}>
+                      <span>{data.betaDownloadLabel}</span>
+                      <span>{data.betaHint}</span>
+                    </a>
+                  </Button>
+                )}
+              </div>
+              <div className="mt-2 flex items-center gap-2">
+                <Badge
+                  variant="outline"
+                  className="bg-green-500 text-white dark:bg-green-600"
+                >
+                  {data.newLabel}
+                </Badge>
+                <span>{data.httpsUpdateSupported}</span>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <span>{data.sightedBySkilledLookouts}</span>
+              <Badge variant="secondary">
+                {data.platformLabels.os[data.platform.os]}
+              </Badge>
+              <Badge variant="secondary">
+                {data.platformLabels.spec[data.platform.spec]}
+              </Badge>
+              <Button variant="link" asChild>
+                <a href={`/${locale}/download`}>{data.downloadOptions}</a>
+              </Button>
+            </div>
+          </>
+        )}
+      </Transition>
     </main>
   )
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,16 +1,30 @@
 /* eslint-disable @next/next/no-css-tags */
 /* eslint-disable @next/next/no-head-element */
 import {
-  createRootRoute,
   HeadContent,
   Scripts,
+  createRootRouteWithContext,
   useRouterState,
 } from '@tanstack/react-router'
+import { Provider as JotaiProvider } from 'jotai'
 
 import '~/styles/globals.css'
 import { defaultLocale, isSupportedLocale } from '~/lib/i18n-routing'
 
-export const Route = createRootRoute({
+export interface TanStackRouterContext {
+  env?: {
+    TANSTACK_TEST_POI_VERSIONS?: string
+  }
+  requestHeaders?: [string, string][]
+  serverContext?: {
+    env?: {
+      TANSTACK_TEST_POI_VERSIONS?: string
+    }
+    requestHeaders?: [string, string][]
+  }
+}
+
+export const Route = createRootRouteWithContext<TanStackRouterContext>()({
   head: () => ({
     meta: [
       { charSet: 'utf-8' },
@@ -56,7 +70,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        {children}
+        <JotaiProvider>{children}</JotaiProvider>
         <Scripts />
       </body>
     </html>

--- a/src/routes/download.tsx
+++ b/src/routes/download.tsx
@@ -1,10 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+import { DownloadLinks } from '~/components/download/download-links'
+import { PlatformSelect } from '~/components/download/platform-select'
+import { Transition } from '~/components/transition'
 import { Button } from '~/components/ui/button'
-import { loadCommonTranslations } from '~/lib/tanstack-page-data'
+import { loadRequestAwarePageData } from '~/lib/tanstack-page-data'
 
 export const Route = createFileRoute('/download')({
-  loader: () => loadCommonTranslations(),
+  loader: ({ context }) => loadRequestAwarePageData(undefined, context),
   head: ({ loaderData }) => ({
     meta: [
       {
@@ -18,41 +21,70 @@ export const Route = createFileRoute('/download')({
 })
 
 function DownloadPage() {
-  const t = Route.useLoaderData()
+  const data = Route.useLoaderData()
   return (
     <main className="prose mx-auto flex min-h-screen max-w-[960px] flex-col justify-center p-4 dark:prose-invert">
-      <h1>{t.download}</h1>
-      <p>{t.mobileHint}</p>
-      <h2>{t.oldVersions}</h2>
-      <div>
-        <Button variant="link" asChild>
-          <a
-            href="https://registry.npmmirror.com/binary.html?path=poi/"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {t.oldVersions}
-          </a>
-        </Button>
-        <Button variant="link" asChild>
-          <a
-            href="https://nightly.poi.moe/"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {t.nightlyBuilds}
-          </a>
-        </Button>
-        <Button variant="link" asChild>
-          <a
-            href="https://github.com/poooi/poi"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {t.sourceCode}
-          </a>
-        </Button>
-      </div>
+      <Transition>
+        <h1>{data.download}</h1>
+        {data.platform.isMobile ? (
+          <p>{data.mobileHint}</p>
+        ) : (
+          <section>
+            <PlatformSelect
+              initialOS={data.platform.os}
+              initialSpec={data.platform.spec}
+              labels={{
+                operatingSystem: data.operatingSystem,
+                os: data.platformLabels.os,
+                platform: data.platformLabel,
+                spec: data.platformLabels.spec,
+              }}
+            />
+            <DownloadLinks
+              labels={{
+                beta: data.betaDownloadLabel,
+                betaHint: data.betaHint,
+                stable: data.stableDownloadLabel,
+                stableHint: data.stableHint,
+              }}
+              poiVersions={data.poiVersions}
+            />
+          </section>
+        )}
+        <h2>{data.others}</h2>
+        <section className="flex w-fit flex-col items-center">
+          <div>
+            <Button variant="link" asChild>
+              <a
+                href="https://registry.npmmirror.com/binary.html?path=poi/"
+                rel="noopener noreferrer"
+                target="_blank"
+                data-testid="old-versions"
+              >
+                {data.oldVersions}
+              </a>
+            </Button>
+            <Button variant="link" asChild>
+              <a
+                href="https://nightly.poi.moe/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {data.nightlyBuilds}
+              </a>
+            </Button>
+            <Button variant="link" asChild>
+              <a
+                href="https://github.com/poooi/poi"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {data.sourceCode}
+              </a>
+            </Button>
+          </div>
+        </section>
+      </Transition>
     </main>
   )
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,11 +1,13 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+/* eslint-disable @next/next/no-html-link-for-pages */
+import { createFileRoute } from '@tanstack/react-router'
 
+import { Transition } from '~/components/transition'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
-import { loadCommonTranslations } from '~/lib/tanstack-page-data'
+import { loadRequestAwarePageData } from '~/lib/tanstack-page-data'
 
 export const Route = createFileRoute('/')({
-  loader: () => loadCommonTranslations(),
+  loader: ({ context }) => loadRequestAwarePageData(undefined, context),
   head: ({ loaderData }) => ({
     meta: [{ title: `poi | ${loaderData?.title ?? '艦これ専ブラ'}` }],
   }),
@@ -13,25 +15,62 @@ export const Route = createFileRoute('/')({
 })
 
 function HomePage() {
-  const t = Route.useLoaderData()
+  const data = Route.useLoaderData()
   return (
     <main className="mx-auto flex min-h-screen max-w-[960px] flex-col items-start justify-center gap-6 bg-background p-4 text-foreground">
-      <h1 className="text-7xl leading-loose">{t.name}</h1>
-      <p className="text-2xl">{t.description}</p>
-      <div className="flex gap-4">
-        <Button asChild>
-          <Link to="/download">{t.download}</Link>
-        </Button>
-        <Button variant="secondary" asChild>
-          <Link to="/explore">{t.explore}</Link>
-        </Button>
-      </div>
-      <div className="flex items-center gap-2">
-        <Badge variant="outline" className="bg-green-500 text-white">
-          {t.newLabel}
-        </Badge>
-        <span>{t.httpsUpdateSupported}</span>
-      </div>
+      <Transition className="w-full">
+        <h1 className="text-7xl leading-loose">{data.name}</h1>
+        <p className="text-2xl">{data.description}</p>
+        {data.platform.isMobile ? (
+          <p className="mt-4">{data.mobileHint}</p>
+        ) : (
+          <>
+            <div className="my-8">
+              <div className="flex gap-8">
+                <Button className="h-fit flex-col" asChild>
+                  <a href={data.stableUrl}>
+                    <span>{data.stableDownloadLabel}</span>
+                    <span>{data.stableHint}</span>
+                  </a>
+                </Button>
+                {data.showBeta && (
+                  <Button
+                    variant="secondary"
+                    className="h-fit flex-col"
+                    asChild
+                  >
+                    <a href={data.betaUrl}>
+                      <span>{data.betaDownloadLabel}</span>
+                      <span>{data.betaHint}</span>
+                    </a>
+                  </Button>
+                )}
+              </div>
+              <div className="mt-2 flex items-center gap-2">
+                <Badge
+                  variant="outline"
+                  className="bg-green-500 text-white dark:bg-green-600"
+                >
+                  {data.newLabel}
+                </Badge>
+                <span>{data.httpsUpdateSupported}</span>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <span>{data.sightedBySkilledLookouts}</span>
+              <Badge variant="secondary">
+                {data.platformLabels.os[data.platform.os]}
+              </Badge>
+              <Badge variant="secondary">
+                {data.platformLabels.spec[data.platform.spec]}
+              </Badge>
+              <Button variant="link" asChild>
+                <a href="/download">{data.downloadOptions}</a>
+              </Button>
+            </div>
+          </>
+        )}
+      </Transition>
     </main>
   )
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -16,6 +16,7 @@ interface AssetsBinding {
 
 interface WorkerEnv {
   ASSETS?: AssetsBinding
+  TANSTACK_TEST_POI_VERSIONS?: string
 }
 
 interface ExecutionContextLike {
@@ -29,6 +30,7 @@ type StartHandlerWithContext = (
     context: {
       ctx: ExecutionContextLike
       env: WorkerEnv
+      requestHeaders: [string, string][]
     }
   },
 ) => Promise<Response>
@@ -273,7 +275,7 @@ const worker = {
     response ??= await (startHandler.fetch as StartHandlerWithContext)(
       request,
       {
-        context: { env, ctx },
+        context: { env, ctx, requestHeaders: [...request.headers] },
       },
     )
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,9 @@ export default defineConfig({
   define: {
     'process.env.BUILD_DATE': JSON.stringify(buildDate),
     'process.env.COMMIT_HASH': JSON.stringify(commitHash),
+    'process.env.TANSTACK_TEST_POI_VERSIONS': JSON.stringify(
+      process.env.TANSTACK_TEST_POI_VERSIONS ?? '',
+    ),
   },
   plugins: [
     cloudflare({


### PR DESCRIPTION
Closes #489

## Summary

- Ports request-aware TanStack home/download rendering to use request headers, client hints, live version metadata, and desktop/mobile branching.
- Adds TanStack-safe download platform controls backed by Jotai, with a per-request Jotai provider to avoid SSR state leakage between users.
- Keeps request-personalized download-option navigation as document navigation until the later client-navigation/provider task can safely own same-document route transitions.
- Hardens target detection for Windows ARM, generic Linux ARM, and Fedora/CentOS ARM.
- Scopes deterministic poi version fixtures to `test:e2e:tanstack` only, so normal TanStack builds do not embed test versions.

## Validation

- `pnpm run lint:next` (passes with existing middleware warning)
- `pnpm run typecheck`
- `pnpm run test:unit`
- `pnpm run check:tanstack-imports`
- `pnpm run test:e2e:tanstack`
- `pnpm run test:e2e:next`
- `pnpm run build:tanstack` without `TANSTACK_TEST_POI_VERSIONS`; verified no fixture version strings in `dist/server/**/*.js`