### PR TITLE
Add TanStack shared navigation providers

### DIFF
--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -115,6 +115,72 @@ test('serves localized download and explore pages', async ({ page }) => {
   await expect(page.locator('main')).toContainText('poi')
 })
 
+test('serves framework-neutral header navigation controls', async ({
+  page,
+}) => {
+  await page.goto('/en')
+
+  await expect(page.getByRole('link', { name: 'poi' })).toHaveAttribute(
+    'href',
+    '/en',
+  )
+  await expect(page.getByAltText('poi')).toHaveAttribute('src', /poi-.*\.png/)
+  await expect(page.getByRole('link', { name: 'Explore' })).toHaveAttribute(
+    'href',
+    '/en/explore',
+  )
+  await expect(
+    page.getByRole('link', { name: 'Download', exact: true }),
+  ).toHaveAttribute('href', '/en/download')
+})
+
+test('keeps header pathname current after client history changes', async ({
+  page,
+}) => {
+  await page.goto('/en')
+  await page.evaluate(() => {
+    window.history.pushState({}, '', '/en/download')
+  })
+
+  await expect(page.getByRole('link', { name: 'poi' })).not.toHaveClass(
+    /opacity-0/,
+  )
+  await page.getByRole('button', { name: 'English' }).click()
+  await page.getByRole('menuitemradio', { name: 'français' }).click()
+  await expect(page).toHaveURL('http://127.0.0.1:3002/fr/download')
+})
+
+test('switches language with NEXT_LOCALE and canonical URL', async ({
+  page,
+}) => {
+  await page.goto('/en')
+
+  await page.getByRole('button', { name: 'English' }).click()
+  await page.getByRole('menuitemradio', { name: 'français' }).click()
+
+  await expect(page).toHaveURL('http://127.0.0.1:3002/fr')
+  await expect(page.locator('html')).toHaveAttribute('lang', 'fr')
+  const cookies = await page.context().cookies('http://127.0.0.1:3002')
+  expect(cookies.find((cookie) => cookie.name === 'NEXT_LOCALE')?.value).toBe(
+    'fr',
+  )
+})
+
+test('switches theme without next-themes', async ({ page }) => {
+  await page.goto('/en')
+
+  await page.getByRole('button', { name: 'Theme' }).click()
+  await page.getByRole('menuitemradio', { name: 'Chibaheit' }).click()
+  await expect(page.locator('html')).toHaveClass(/dark/)
+  await expect(
+    page.evaluate(() => localStorage.getItem('theme')),
+  ).resolves.toBe('dark')
+
+  await page.getByRole('button', { name: 'Theme' }).click()
+  await page.getByRole('menuitemradio', { name: 'Lilywhite' }).click()
+  await expect(page.locator('html')).not.toHaveClass(/dark/)
+})
+
 test('renders desktop request-aware download links', async ({ browser }) => {
   const context = await browser.newContext({
     baseURL: 'http://127.0.0.1:3002',
@@ -147,7 +213,10 @@ test('renders desktop request-aware download links', async ({ browser }) => {
     page.getByRole('link', { name: /Download v10\.9\.2/ }),
   ).toHaveAttribute('href', '/dist/poi-setup-10.9.2.exe')
   await expect(page.getByText('Operating system')).toBeVisible()
-  const platformButtons = page.getByRole('button')
+  const platformControls = page
+    .locator('section')
+    .filter({ hasText: 'Operating system' })
+  const platformButtons = platformControls.getByRole('button')
   await expect(platformButtons).toHaveCount(2)
   await platformButtons.first().click()
   const linuxItem = page.getByRole('menuitem', { name: 'Linux' })

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -261,6 +261,32 @@ test('ignores invalid stored theme values', async ({ page }) => {
   await expect(page.locator('html')).toHaveClass(/dark/)
 })
 
+test('theme switching works when localStorage is unavailable', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    baseURL: 'http://127.0.0.1:3002',
+  })
+  await context.addInitScript(() => {
+    Storage.prototype.getItem = () => {
+      throw new Error('localStorage disabled')
+    }
+    Storage.prototype.setItem = () => {
+      throw new Error('localStorage disabled')
+    }
+  })
+  const page = await context.newPage()
+
+  await page.goto('/en')
+  await page.getByRole('button', { name: 'Theme' }).click()
+  await page.getByRole('menuitemradio', { name: 'Chibaheit' }).click()
+  await expect(page.locator('html')).toHaveClass(/dark/)
+  const cookies = await page.context().cookies('http://127.0.0.1:3002')
+  expect(cookies.find((cookie) => cookie.name === 'theme')?.value).toBe('dark')
+
+  await context.close()
+})
+
 test('does not mount background canvas on small screens', async ({ page }) => {
   await page.setViewportSize({ width: 500, height: 800 })
   await page.goto('/en')

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -186,6 +186,7 @@ test('switches theme without next-themes', async ({ page }) => {
 })
 
 test('uses theme cookie for server-rendered explicit dark theme', async ({
+  page,
   request,
 }) => {
   const response = await request.get('/en', {
@@ -194,10 +195,20 @@ test('uses theme cookie for server-rendered explicit dark theme', async ({
     },
   })
 
-  expect(await response.text()).toContain('<html lang="en" class="dark')
+  expect(await response.text()).toContain("classList.add('dark')")
+  await page.context().addCookies([
+    {
+      name: 'theme',
+      url: 'http://127.0.0.1:3002',
+      value: 'dark',
+    },
+  ])
+  await page.goto('/en')
+  await expect(page.locator('html')).toHaveClass(/dark/)
 })
 
 test('uses Sec-CH-Prefers-Color-Scheme for server-rendered system theme', async ({
+  browser,
   request,
 }) => {
   const response = await request.get('/en', {
@@ -206,7 +217,21 @@ test('uses Sec-CH-Prefers-Color-Scheme for server-rendered system theme', async 
     },
   })
 
-  expect(await response.text()).toContain('<html lang="en" class="dark')
+  expect(await response.text()).toContain("classList.add('dark')")
+  const context = await browser.newContext({
+    baseURL: 'http://127.0.0.1:3002',
+    colorScheme: 'dark',
+    extraHTTPHeaders: {
+      'Sec-CH-Prefers-Color-Scheme': '"dark"',
+    },
+  })
+  const page = await context.newPage()
+  await page.setExtraHTTPHeaders({
+    'Sec-CH-Prefers-Color-Scheme': '"dark"',
+  })
+  await page.goto('/en')
+  await expect(page.locator('html')).toHaveClass(/dark/)
+  await context.close()
 })
 
 test('keeps system theme selected after client-hint dark SSR', async ({

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -197,6 +197,43 @@ test('uses theme cookie for server-rendered explicit dark theme', async ({
   expect(await response.text()).toContain('<html lang="en" class="dark')
 })
 
+test('uses Sec-CH-Prefers-Color-Scheme for server-rendered system theme', async ({
+  request,
+}) => {
+  const response = await request.get('/en', {
+    headers: {
+      'Sec-CH-Prefers-Color-Scheme': '"dark"',
+    },
+  })
+
+  expect(await response.text()).toContain('<html lang="en" class="dark')
+})
+
+test('keeps system theme selected after client-hint dark SSR', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    baseURL: 'http://127.0.0.1:3002',
+    colorScheme: 'dark',
+    extraHTTPHeaders: {
+      'Sec-CH-Prefers-Color-Scheme': '"dark"',
+    },
+  })
+  const page = await context.newPage()
+
+  await page.goto('/en')
+  await expect(page.locator('html')).toHaveClass(/dark/)
+  await page.getByRole('button', { name: 'Theme' }).click()
+  await expect(
+    page.getByRole('menuitemradio', { name: 'System' }),
+  ).toHaveAttribute('aria-checked', 'true')
+
+  await page.emulateMedia({ colorScheme: 'light' })
+  await expect(page.locator('html')).not.toHaveClass(/dark/)
+
+  await context.close()
+})
+
 test('ignores malformed theme cookies during SSR', async ({ request }) => {
   const response = await request.get('/en', {
     headers: {

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -175,10 +175,53 @@ test('switches theme without next-themes', async ({ page }) => {
   await expect(
     page.evaluate(() => localStorage.getItem('theme')),
   ).resolves.toBe('dark')
+  const darkCookies = await page.context().cookies('http://127.0.0.1:3002')
+  expect(darkCookies.find((cookie) => cookie.name === 'theme')?.value).toBe(
+    'dark',
+  )
 
   await page.getByRole('button', { name: 'Theme' }).click()
   await page.getByRole('menuitemradio', { name: 'Lilywhite' }).click()
   await expect(page.locator('html')).not.toHaveClass(/dark/)
+})
+
+test('uses theme cookie for server-rendered explicit dark theme', async ({
+  request,
+}) => {
+  const response = await request.get('/en', {
+    headers: {
+      Cookie: 'theme=dark',
+    },
+  })
+
+  expect(await response.text()).toContain('<html lang="en" class="dark')
+})
+
+test('ignores malformed theme cookies during SSR', async ({ request }) => {
+  const response = await request.get('/en', {
+    headers: {
+      Cookie: 'theme=%',
+    },
+  })
+
+  expect(response.status()).toBe(200)
+})
+
+test('ignores invalid stored theme values', async ({ page }) => {
+  await page.goto('/en')
+  await page.evaluate(() => localStorage.setItem('theme', 'invalid'))
+  await page.reload()
+
+  await page.getByRole('button', { name: 'Theme' }).click()
+  await page.getByRole('menuitemradio', { name: 'Chibaheit' }).click()
+  await expect(page.locator('html')).toHaveClass(/dark/)
+})
+
+test('does not mount background canvas on small screens', async ({ page }) => {
+  await page.setViewportSize({ width: 500, height: 800 })
+  await page.goto('/en')
+
+  await expect(page.locator('canvas')).toHaveCount(0)
 })
 
 test('renders desktop request-aware download links', async ({ browser }) => {

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -230,6 +230,13 @@ test('keeps system theme selected after client-hint dark SSR', async ({
 
   await page.emulateMedia({ colorScheme: 'light' })
   await expect(page.locator('html')).not.toHaveClass(/dark/)
+  await expect(
+    page
+      .locator('canvas')
+      .evaluate((canvas: HTMLCanvasElement) =>
+        canvas.getContext('2d')?.getImageData(0, 0, 1, 1).data.join(','),
+      ),
+  ).resolves.toBeDefined()
 
   await context.close()
 })

--- a/specs-tanstack/scaffold.spec.ts
+++ b/specs-tanstack/scaffold.spec.ts
@@ -25,8 +25,11 @@ test('renders the isolated TanStack preview route', async ({ page }) => {
   expect(headers['x-poi-codename']).toBe('Shiratsuyu')
   expect(headers['x-poi-greetings']).toBe('poi?')
   expect(headers['accept-ch']).toContain('Sec-CH-UA-Platform')
+  expect(headers['accept-ch']).toContain('Sec-CH-Prefers-Color-Scheme')
   expect(headers['critical-ch']).toContain('Sec-CH-UA-Platform')
+  expect(headers['critical-ch']).toContain('Sec-CH-Prefers-Color-Scheme')
   expect(headers.vary).toContain('Sec-CH-UA-Platform')
+  expect(headers.vary).toContain('Sec-CH-Prefers-Color-Scheme')
   expect(headers['cache-control']).toBe('no-store')
 })
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import { DesktopBackground } from '~/components/desktop-background'
 import { Footer } from '~/components/footer'
 import { Header } from '~/components/header'
 import { I18nProvider } from '~/components/i18n-provider'
+import { JotaiRootProvider } from '~/components/jotai-provider'
 import { ThemeProvider } from '~/components/theme-provider'
 import { initTranslations } from '~/i18n'
 import { i18nConfig } from '~/i18n-config'
@@ -113,25 +114,30 @@ export default async function RootLayout(
         )}
       </head>
       <body>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme={themePreference}
-          enableSystem
-          disableTransitionOnChange
+        <JotaiRootProvider
+          initialResolvedTheme={theme ?? 'light'}
+          initialTheme={themePreference}
         >
-          <DesktopBackground initialEnabled={!isMobile} />
-          <I18nProvider
-            locale={locale}
-            namespaces={['common']}
-            resources={resources}
+          <ThemeProvider
+            attribute="class"
+            defaultTheme={themePreference}
+            enableSystem
+            disableTransitionOnChange
           >
-            <main className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">
-              <Header />
-              {children}
-              <Footer t={t} i18n={i18n} />
-            </main>
-          </I18nProvider>
-        </ThemeProvider>
+            <DesktopBackground initialEnabled={!isMobile} />
+            <I18nProvider
+              locale={locale}
+              namespaces={['common']}
+              resources={resources}
+            >
+              <main className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">
+                <Header />
+                {children}
+                <Footer t={t} i18n={i18n} />
+              </main>
+            </I18nProvider>
+          </ThemeProvider>
+        </JotaiRootProvider>
       </body>
     </html>
   )

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,7 +5,7 @@ import '~/styles/globals.css'
 import type { Metadata } from 'next'
 import { headers } from 'next/headers'
 
-import { Background } from '~/components/background'
+import { DesktopBackground } from '~/components/desktop-background'
 import { Footer } from '~/components/footer'
 import { Header } from '~/components/header'
 import { I18nProvider } from '~/components/i18n-provider'
@@ -13,6 +13,7 @@ import { ThemeProvider } from '~/components/theme-provider'
 import { initTranslations } from '~/i18n'
 import { i18nConfig } from '~/i18n-config'
 import { isMobileDevice } from '~/lib/target'
+import { getThemeCookie } from '~/lib/theme'
 import { cn } from '~/lib/utils'
 
 export const generateStaticParams = async () => {
@@ -64,13 +65,16 @@ export default async function RootLayout(
 
   const { resources, t, i18n } = await initTranslations(locale, ['common'])
 
-  const isMobile = await isMobileDevice(await headers())
+  const requestHeaders = await headers()
+  const isMobile = await isMobileDevice(requestHeaders)
+  const theme = getThemeCookie(requestHeaders.get('Cookie'))
 
   return (
     <html
       lang={locale}
       className={cn({
         'font-ja': locale === 'ja',
+        dark: theme === 'dark',
         'font-zh-hant': locale === 'zh-Hant',
         'font-zh-hans': locale === 'zh-Hans',
         'font-ko': locale === 'ko',
@@ -110,11 +114,11 @@ export default async function RootLayout(
       <body>
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme={theme ?? 'system'}
           enableSystem
           disableTransitionOnChange
         >
-          {!isMobile && <Background />}
+          <DesktopBackground initialEnabled={!isMobile} />
           <I18nProvider
             locale={locale}
             namespaces={['common']}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,7 +10,7 @@ import { Footer } from '~/components/footer'
 import { Header } from '~/components/header'
 import { I18nProvider } from '~/components/i18n-provider'
 import { JotaiRootProvider } from '~/components/jotai-provider'
-import { ThemeProvider } from '~/components/theme-provider'
+import { ThemeRuntime } from '~/components/theme-runtime'
 import { initTranslations } from '~/i18n'
 import { i18nConfig } from '~/i18n-config'
 import { isMobileDevice } from '~/lib/target'
@@ -118,25 +118,23 @@ export default async function RootLayout(
           initialResolvedTheme={theme ?? 'light'}
           initialTheme={themePreference}
         >
-          <ThemeProvider
-            attribute="class"
+          <ThemeRuntime
             defaultTheme={themePreference}
             enableSystem
             disableTransitionOnChange
+          />
+          <DesktopBackground initialEnabled={!isMobile} />
+          <I18nProvider
+            locale={locale}
+            namespaces={['common']}
+            resources={resources}
           >
-            <DesktopBackground initialEnabled={!isMobile} />
-            <I18nProvider
-              locale={locale}
-              namespaces={['common']}
-              resources={resources}
-            >
-              <main className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">
-                <Header />
-                {children}
-                <Footer t={t} i18n={i18n} />
-              </main>
-            </I18nProvider>
-          </ThemeProvider>
+            <main className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">
+              <Header />
+              {children}
+              <Footer t={t} i18n={i18n} />
+            </main>
+          </I18nProvider>
         </JotaiRootProvider>
       </body>
     </html>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -13,7 +13,7 @@ import { ThemeProvider } from '~/components/theme-provider'
 import { initTranslations } from '~/i18n'
 import { i18nConfig } from '~/i18n-config'
 import { isMobileDevice } from '~/lib/target'
-import { getThemeCookie } from '~/lib/theme'
+import { getServerThemePreference, resolveServerTheme } from '~/lib/theme'
 import { cn } from '~/lib/utils'
 
 export const generateStaticParams = async () => {
@@ -67,7 +67,8 @@ export default async function RootLayout(
 
   const requestHeaders = await headers()
   const isMobile = await isMobileDevice(requestHeaders)
-  const theme = getThemeCookie(requestHeaders.get('Cookie'))
+  const theme = resolveServerTheme(requestHeaders)
+  const themePreference = getServerThemePreference(requestHeaders)
 
   return (
     <html
@@ -114,7 +115,7 @@ export default async function RootLayout(
       <body>
         <ThemeProvider
           attribute="class"
-          defaultTheme={theme ?? 'system'}
+          defaultTheme={themePreference}
           enableSystem
           disableTransitionOnChange
         >

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,7 +7,7 @@ import { headers } from 'next/headers'
 
 import { DesktopBackground } from '~/components/desktop-background'
 import { Footer } from '~/components/footer'
-import { Header } from '~/components/header'
+import { HeaderNext } from '~/components/header-next'
 import { I18nProvider } from '~/components/i18n-provider'
 import { JotaiRootProvider } from '~/components/jotai-provider'
 import { ThemeRuntime } from '~/components/theme-runtime'
@@ -130,7 +130,7 @@ export default async function RootLayout(
             resources={resources}
           >
             <main className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">
-              <Header />
+              <HeaderNext />
               {children}
               <Footer t={t} i18n={i18n} />
             </main>

--- a/src/components/background.tsx
+++ b/src/components/background.tsx
@@ -2,10 +2,11 @@
 
 import debounce from 'lodash/debounce'
 import times from 'lodash/times'
-import { useTheme } from 'next-themes'
 import { rgba } from 'polished'
 import random from 'random'
 import { useEffect, useRef } from 'react'
+
+import { useTheme } from '~/components/theme-provider'
 
 /**
  * Draws an hexagone

--- a/src/components/background.tsx
+++ b/src/components/background.tsx
@@ -59,7 +59,7 @@ const getRandomXY = (w: number, h: number) => {
 
 export const Background = () => {
   const canvas = useRef<HTMLCanvasElement>(null)
-  const { theme } = useTheme()
+  const { resolvedTheme } = useTheme()
 
   useEffect(() => {
     const drawCanvas = () => {
@@ -103,7 +103,7 @@ export const Background = () => {
     return () => {
       window.removeEventListener('resize', debouncedDrawCanvas)
     }
-  }, [theme])
+  }, [resolvedTheme])
 
   return (
     <canvas

--- a/src/components/background.tsx
+++ b/src/components/background.tsx
@@ -6,7 +6,7 @@ import { rgba } from 'polished'
 import random from 'random'
 import { useEffect, useRef } from 'react'
 
-import { useTheme } from '~/components/theme-provider'
+import { useTheme } from '~/components/theme-runtime'
 
 /**
  * Draws an hexagone

--- a/src/components/desktop-background.tsx
+++ b/src/components/desktop-background.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Background } from '~/components/background'
+
+interface DesktopBackgroundProps {
+  initialEnabled?: boolean
+}
+
+export const DesktopBackground = ({
+  initialEnabled = false,
+}: DesktopBackgroundProps) => {
+  const [enabled, setEnabled] = useState(initialEnabled)
+
+  useEffect(() => {
+    const media = window.matchMedia('(min-width: 768px)')
+    const handleChange = () => setEnabled(media.matches)
+    handleChange()
+    media.addEventListener('change', handleChange)
+    return () => media.removeEventListener('change', handleChange)
+  }, [])
+
+  return enabled ? <Background /> : null
+}

--- a/src/components/footer-client.tsx
+++ b/src/components/footer-client.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { useTranslation } from 'react-i18next'
+
+import { Footer } from '~/components/footer'
+
+export const FooterClient = () => {
+  const { i18n, t } = useTranslation()
+  return <Footer i18n={i18n} t={t} />
+}

--- a/src/components/header-next.tsx
+++ b/src/components/header-next.tsx
@@ -1,16 +1,20 @@
 'use client'
 
 import Link from 'next/link'
+import { forwardRef } from 'react'
 
 import { Header, type HeaderLinkProps } from '~/components/header'
 
-const NextHeaderLink = ({ children, href, ...props }: HeaderLinkProps) => {
-  return (
-    <Link href={href} {...props}>
-      {children}
-    </Link>
-  )
-}
+const NextHeaderLink = forwardRef<HTMLAnchorElement, HeaderLinkProps>(
+  ({ children, href, ...props }, ref) => {
+    return (
+      <Link href={href} ref={ref} {...props}>
+        {children}
+      </Link>
+    )
+  },
+)
+NextHeaderLink.displayName = 'NextHeaderLink'
 
 export const HeaderNext = () => {
   return <Header LinkComponent={NextHeaderLink} />

--- a/src/components/header-next.tsx
+++ b/src/components/header-next.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import Link from 'next/link'
+
+import { Header, type HeaderLinkProps } from '~/components/header'
+
+const NextHeaderLink = ({ children, href, ...props }: HeaderLinkProps) => {
+  return (
+    <Link href={href} {...props}>
+      {children}
+    </Link>
+  )
+}
+
+export const HeaderNext = () => {
+  return <Header LinkComponent={NextHeaderLink} />
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
+/* eslint-disable @next/next/no-html-link-for-pages */
 'use client'
 
-import Link from 'next/link'
 import { useTranslation } from 'react-i18next'
 
 import poiLogo from '~/assets/poi.png'
@@ -9,10 +9,13 @@ import { LanguageChooser } from '~/components/language-chooser'
 import { ThemeChooser } from '~/components/theme-chooser'
 import { Button } from '~/components/ui/button'
 import { useI18nPathname } from '~/hooks/use-i18n-pathname'
+import { localizePath } from '~/lib/i18n-routing'
 import { cn } from '~/lib/utils'
 
+const poiLogoSrc = typeof poiLogo === 'string' ? poiLogo : poiLogo.src
+
 export const Header = () => {
-  const { t } = useTranslation()
+  const { i18n, t } = useTranslation()
   const pathname = useI18nPathname()
 
   const onIndexPage = pathname === '/'
@@ -21,17 +24,18 @@ export const Header = () => {
     <div className="flex h-16 w-full items-center">
       <nav className="flex grow items-center">
         <Button variant="ghost" size="icon" asChild>
-          <Link className={cn(onIndexPage && 'cursor-auto opacity-0')} href="/">
-            <img src={poiLogo.src} alt="poi" className="h-8 w-8" />
-          </Link>
+          <a
+            className={cn(onIndexPage && 'cursor-auto opacity-0')}
+            href={localizePath('/', i18n.language)}
+          >
+            <img src={poiLogoSrc} alt="poi" className="h-8 w-8" />
+          </a>
         </Button>
         <Button variant="ghost" asChild>
-          <Link href="/explore">{t('Explore')}</Link>
+          <a href={localizePath('/explore', i18n.language)}>{t('Explore')}</a>
         </Button>
         <Button variant="ghost" asChild>
-          <Link href="/download" passHref>
-            {t('Download')}
-          </Link>
+          <a href={localizePath('/download', i18n.language)}>{t('Download')}</a>
         </Button>
       </nav>
       <div className="flex shrink-0 gap-4">

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
-/* eslint-disable @next/next/no-html-link-for-pages */
 'use client'
 
+import { type ComponentType, type PropsWithChildren } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import poiLogo from '~/assets/poi.png'
@@ -14,7 +14,20 @@ import { cn } from '~/lib/utils'
 
 const poiLogoSrc = typeof poiLogo === 'string' ? poiLogo : poiLogo.src
 
-export const Header = () => {
+export interface HeaderLinkProps extends PropsWithChildren {
+  className?: string
+  href: string
+}
+
+const AnchorLink = ({ children, ...props }: HeaderLinkProps) => {
+  return <a {...props}>{children}</a>
+}
+
+interface HeaderProps {
+  LinkComponent?: ComponentType<HeaderLinkProps>
+}
+
+export const Header = ({ LinkComponent = AnchorLink }: HeaderProps) => {
   const { i18n, t } = useTranslation()
   const pathname = useI18nPathname()
 
@@ -24,18 +37,22 @@ export const Header = () => {
     <div className="flex h-16 w-full items-center">
       <nav className="flex grow items-center">
         <Button variant="ghost" size="icon" asChild>
-          <a
+          <LinkComponent
             className={cn(onIndexPage && 'cursor-auto opacity-0')}
             href={localizePath('/', i18n.language)}
           >
             <img src={poiLogoSrc} alt="poi" className="h-8 w-8" />
-          </a>
+          </LinkComponent>
         </Button>
         <Button variant="ghost" asChild>
-          <a href={localizePath('/explore', i18n.language)}>{t('Explore')}</a>
+          <LinkComponent href={localizePath('/explore', i18n.language)}>
+            {t('Explore')}
+          </LinkComponent>
         </Button>
         <Button variant="ghost" asChild>
-          <a href={localizePath('/download', i18n.language)}>{t('Download')}</a>
+          <LinkComponent href={localizePath('/download', i18n.language)}>
+            {t('Download')}
+          </LinkComponent>
         </Button>
       </nav>
       <div className="flex shrink-0 gap-4">

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,7 +1,11 @@
 /* eslint-disable @next/next/no-img-element */
 'use client'
 
-import { type ComponentType, type PropsWithChildren } from 'react'
+import {
+  forwardRef,
+  type ComponentType,
+  type ComponentPropsWithoutRef,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 
 import poiLogo from '~/assets/poi.png'
@@ -14,14 +18,20 @@ import { cn } from '~/lib/utils'
 
 const poiLogoSrc = typeof poiLogo === 'string' ? poiLogo : poiLogo.src
 
-export interface HeaderLinkProps extends PropsWithChildren {
-  className?: string
+export interface HeaderLinkProps extends ComponentPropsWithoutRef<'a'> {
   href: string
 }
 
-const AnchorLink = ({ children, ...props }: HeaderLinkProps) => {
-  return <a {...props}>{children}</a>
-}
+const AnchorLink = forwardRef<HTMLAnchorElement, HeaderLinkProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <a ref={ref} {...props}>
+        {children}
+      </a>
+    )
+  },
+)
+AnchorLink.displayName = 'AnchorLink'
 
 interface HeaderProps {
   LinkComponent?: ComponentType<HeaderLinkProps>

--- a/src/components/jotai-provider.tsx
+++ b/src/components/jotai-provider.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { Provider as JotaiProvider } from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
+import { type PropsWithChildren } from 'react'
+
+import { resolvedThemeAtom, themeAtom } from '~/components/theme-atoms'
+import { type Theme } from '~/lib/theme'
+
+interface JotaiRootProviderProps extends PropsWithChildren {
+  initialResolvedTheme?: 'dark' | 'light'
+  initialTheme?: Theme
+}
+
+const HydrateAtoms = ({
+  children,
+  initialResolvedTheme = 'light',
+  initialTheme = 'system',
+}: JotaiRootProviderProps) => {
+  useHydrateAtoms([
+    [themeAtom, initialTheme],
+    [resolvedThemeAtom, initialResolvedTheme],
+  ])
+
+  return <>{children}</>
+}
+
+export const JotaiRootProvider = ({
+  children,
+  initialResolvedTheme,
+  initialTheme,
+}: JotaiRootProviderProps) => {
+  return (
+    <JotaiProvider>
+      <HydrateAtoms
+        initialResolvedTheme={initialResolvedTheme}
+        initialTheme={initialTheme}
+      >
+        {children}
+      </HydrateAtoms>
+    </JotaiProvider>
+  )
+}

--- a/src/components/language-chooser.tsx
+++ b/src/components/language-chooser.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { GlobeIcon } from '@radix-ui/react-icons'
-import { useRouter, usePathname } from 'next/navigation'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -13,35 +12,27 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '~/components/ui/dropdown-menu'
+import { useI18nPathname } from '~/hooks/use-i18n-pathname'
 import { i18nConfig } from '~/i18n-config'
+import { localizePath } from '~/lib/i18n-routing'
 
 export const LanguageChooser = () => {
   const { t, i18n } = useTranslation()
   const currentLocale = i18n.language
-  const router = useRouter()
-  const currentPathname = usePathname()
+  const currentPathname = useI18nPathname()
 
   const handleChange = useCallback(
     (newLocale: string) => {
-      // set cookie for next-i18n-router
+      // Keep the existing locale cookie name for migration compatibility.
       const days = 30
       const date = new Date()
       date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000)
       const expires = date.toUTCString()
       document.cookie = `NEXT_LOCALE=${newLocale};expires=${expires};path=/`
 
-      // redirect to the new locale path
-      if (currentLocale === i18nConfig.defaultLocale) {
-        router.push('/' + newLocale + currentPathname)
-      } else {
-        router.push(
-          currentPathname.replace(`/${currentLocale}`, `/${newLocale}`),
-        )
-      }
-
-      router.refresh()
+      window.location.assign(localizePath(currentPathname, newLocale))
     },
-    [currentLocale, currentPathname, router],
+    [currentPathname],
   )
 
   return (

--- a/src/components/language-chooser.tsx
+++ b/src/components/language-chooser.tsx
@@ -30,7 +30,8 @@ export const LanguageChooser = () => {
       const expires = date.toUTCString()
       document.cookie = `NEXT_LOCALE=${newLocale};expires=${expires};path=/`
 
-      window.location.assign(localizePath(currentPathname, newLocale))
+      const pathname = currentPathname ?? window.location.pathname
+      window.location.assign(localizePath(pathname, newLocale))
     },
     [currentPathname],
   )

--- a/src/components/theme-atoms.ts
+++ b/src/components/theme-atoms.ts
@@ -1,0 +1,7 @@
+import { atom } from 'jotai'
+
+import { type Theme } from '~/lib/theme'
+
+export const themeAtom = atom<Theme>('system')
+
+export const resolvedThemeAtom = atom<'dark' | 'light'>('light')

--- a/src/components/theme-chooser.tsx
+++ b/src/components/theme-chooser.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { MoonIcon, SunIcon } from 'lucide-react'
-import { useTheme } from 'next-themes'
 import { useTranslation } from 'react-i18next'
 
+import { type Theme, useTheme } from '~/components/theme-provider'
 import { Button } from '~/components/ui/button'
 import {
   DropdownMenu,
@@ -17,6 +17,11 @@ export const ThemeChooser = () => {
   const { theme, setTheme } = useTheme()
 
   const { t } = useTranslation()
+  const handleThemeChange = (value: string) => {
+    if (value === 'dark' || value === 'light' || value === 'system') {
+      setTheme(value satisfies Theme)
+    }
+  }
 
   return (
     <DropdownMenu>
@@ -33,7 +38,7 @@ export const ThemeChooser = () => {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuRadioGroup value={theme} onValueChange={setTheme}>
+        <DropdownMenuRadioGroup value={theme} onValueChange={handleThemeChange}>
           <DropdownMenuRadioItem value="light">
             {t('Lilywhite')}
           </DropdownMenuRadioItem>

--- a/src/components/theme-chooser.tsx
+++ b/src/components/theme-chooser.tsx
@@ -3,7 +3,7 @@
 import { MoonIcon, SunIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { useTheme } from '~/components/theme-provider'
+import { useTheme } from '~/components/theme-runtime'
 import { Button } from '~/components/ui/button'
 import {
   DropdownMenu,

--- a/src/components/theme-chooser.tsx
+++ b/src/components/theme-chooser.tsx
@@ -3,7 +3,7 @@
 import { MoonIcon, SunIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { type Theme, useTheme } from '~/components/theme-provider'
+import { useTheme } from '~/components/theme-provider'
 import { Button } from '~/components/ui/button'
 import {
   DropdownMenu,
@@ -12,6 +12,7 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '~/components/ui/dropdown-menu'
+import { type Theme } from '~/lib/theme'
 
 export const ThemeChooser = () => {
   const { theme, setTheme } = useTheme()

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -30,6 +30,8 @@ interface ThemeProviderProps extends PropsWithChildren {
 }
 
 const storageKey = themeCookieName
+const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect
 
 const themeAtom = atom<Theme>('system')
 const resolvedThemeAtom = atom<'dark' | 'light'>('light')
@@ -51,7 +53,7 @@ const disableTransitions = () => {
 }
 
 const setThemeCookie = (theme: Theme) => {
-  document.cookie = `${themeCookieName}=${theme};max-age=31536000;path=/;sameSite=lax`
+  document.cookie = `${themeCookieName}=${theme};max-age=31536000;path=/;SameSite=Lax`
 }
 
 const getStoredTheme = () => {
@@ -124,7 +126,7 @@ const ThemeHydrator = ({
   const setResolvedTheme = useSetAtom(resolvedThemeAtom)
   const skipThemeEffect = useRef(true)
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const cookieTheme = getThemeCookie(document.cookie)
     const initialTheme = cookieTheme ?? getStoredTheme() ?? defaultTheme
     setTheme(initialTheme)

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -128,6 +128,8 @@ const ThemeHydrator = ({
     const cookieTheme = getThemeCookie(document.cookie)
     const initialTheme = cookieTheme ?? getStoredTheme() ?? defaultTheme
     setTheme(initialTheme)
+    setStoredTheme(initialTheme)
+    setThemeCookie(initialTheme)
     setResolvedTheme(
       applyTheme(initialTheme, enableSystem, disableTransitionOnChange),
     )

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -8,7 +8,12 @@ import {
   useSetAtom,
 } from 'jotai'
 import { useHydrateAtoms } from 'jotai/utils'
-import { useEffect, useRef, type PropsWithChildren } from 'react'
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type PropsWithChildren,
+} from 'react'
 
 import {
   getThemeCookie,
@@ -27,6 +32,7 @@ interface ThemeProviderProps extends PropsWithChildren {
 const storageKey = themeCookieName
 
 const themeAtom = atom<Theme>('system')
+const resolvedThemeAtom = atom<'dark' | 'light'>('light')
 
 const getSystemTheme = () => {
   return window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -52,14 +58,21 @@ const applyTheme = (
   theme: Theme,
   enableSystem: boolean,
   disableTransitionOnChange: boolean,
-) => {
+): 'dark' | 'light' => {
   const restoreTransitions = disableTransitionOnChange
     ? disableTransitions()
     : undefined
   const resolvedTheme =
-    theme === 'system' && enableSystem ? getSystemTheme() : theme
+    theme === 'dark'
+      ? 'dark'
+      : theme === 'light'
+        ? 'light'
+        : enableSystem
+          ? getSystemTheme()
+          : 'light'
   document.documentElement.classList.toggle('dark', resolvedTheme === 'dark')
   restoreTransitions?.()
+  return resolvedTheme
 }
 
 export const ThemeProvider = ({
@@ -91,16 +104,25 @@ const ThemeHydrator = ({
 }: ThemeProviderProps) => {
   useHydrateAtoms([[themeAtom, defaultTheme]])
   const [theme, setTheme] = useAtom(themeAtom)
+  const setResolvedTheme = useSetAtom(resolvedThemeAtom)
   const skipThemeEffect = useRef(true)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const cookieTheme = getThemeCookie(document.cookie)
     const storedTheme = window.localStorage.getItem(storageKey)
     const initialTheme =
       cookieTheme ?? (isTheme(storedTheme) ? storedTheme : defaultTheme)
     setTheme(initialTheme)
-    applyTheme(initialTheme, enableSystem, disableTransitionOnChange)
-  }, [defaultTheme, disableTransitionOnChange, enableSystem, setTheme])
+    setResolvedTheme(
+      applyTheme(initialTheme, enableSystem, disableTransitionOnChange),
+    )
+  }, [
+    defaultTheme,
+    disableTransitionOnChange,
+    enableSystem,
+    setResolvedTheme,
+    setTheme,
+  ])
 
   useEffect(() => {
     const skipPersistence = skipThemeEffect.current
@@ -111,23 +133,27 @@ const ThemeHydrator = ({
     if (!skipPersistence) {
       window.localStorage.setItem(storageKey, theme)
       setThemeCookie(theme)
-      applyTheme(theme, enableSystem, disableTransitionOnChange)
+      setResolvedTheme(
+        applyTheme(theme, enableSystem, disableTransitionOnChange),
+      )
     }
 
     if (enableSystem && theme === 'system') {
       const media = window.matchMedia('(prefers-color-scheme: dark)')
-      const handleChange = () =>
-        applyTheme('system', true, disableTransitionOnChange)
+      const handleChange = () => {
+        setResolvedTheme(applyTheme('system', true, disableTransitionOnChange))
+      }
       media.addEventListener('change', handleChange)
       return () => media.removeEventListener('change', handleChange)
     }
-  }, [disableTransitionOnChange, enableSystem, theme])
+  }, [disableTransitionOnChange, enableSystem, setResolvedTheme, theme])
 
   return <>{children}</>
 }
 
 export const useTheme = () => {
   return {
+    resolvedTheme: useAtomValue(resolvedThemeAtom),
     setTheme: useSetAtom(themeAtom),
     theme: useAtomValue(themeAtom),
   }

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,16 +1,20 @@
 'use client'
 
 import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type PropsWithChildren,
-} from 'react'
+  atom,
+  Provider as JotaiProvider,
+  useAtomValue,
+  useSetAtom,
+} from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
+import { useEffect, type PropsWithChildren } from 'react'
 
-export type Theme = 'dark' | 'light' | 'system'
+import {
+  getThemeCookie,
+  isTheme,
+  themeCookieName,
+  type Theme,
+} from '~/lib/theme'
 
 interface ThemeProviderProps extends PropsWithChildren {
   attribute?: 'class'
@@ -19,14 +23,11 @@ interface ThemeProviderProps extends PropsWithChildren {
   enableSystem?: boolean
 }
 
-interface ThemeContextValue {
-  setTheme: (theme: Theme) => void
-  theme: Theme
-}
+const storageKey = themeCookieName
 
-const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
-
-const storageKey = 'theme'
+const themeAtom = atom<Theme>('system')
+const enableSystemAtom = atom(true)
+const disableTransitionOnChangeAtom = atom(false)
 
 const getSystemTheme = () => {
   return window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -34,25 +35,93 @@ const getSystemTheme = () => {
     : 'light'
 }
 
-const applyTheme = (theme: Theme, enableSystem: boolean) => {
+const disableTransitions = () => {
+  const style = document.createElement('style')
+  style.appendChild(document.createTextNode('*{transition:none!important}'))
+  document.head.appendChild(style)
+  window.getComputedStyle(document.body)
+  return () => {
+    style.remove()
+  }
+}
+
+const setThemeCookie = (theme: Theme) => {
+  document.cookie = `${themeCookieName}=${theme};max-age=31536000;path=/;sameSite=lax`
+}
+
+const applyTheme = (
+  theme: Theme,
+  enableSystem: boolean,
+  disableTransitionOnChange: boolean,
+) => {
+  const restoreTransitions = disableTransitionOnChange
+    ? disableTransitions()
+    : undefined
   const resolvedTheme =
     theme === 'system' && enableSystem ? getSystemTheme() : theme
   document.documentElement.classList.toggle('dark', resolvedTheme === 'dark')
+  restoreTransitions?.()
 }
 
+const setThemeAtom = atom(null, (get, set, nextTheme: Theme) => {
+  const enableSystem = get(enableSystemAtom)
+  const disableTransitionOnChange = get(disableTransitionOnChangeAtom)
+  window.localStorage.setItem(storageKey, nextTheme)
+  setThemeCookie(nextTheme)
+  set(themeAtom, nextTheme)
+  applyTheme(nextTheme, enableSystem, disableTransitionOnChange)
+})
+
 export const ThemeProvider = ({
+  attribute = 'class',
   children,
   defaultTheme = 'system',
+  disableTransitionOnChange = false,
   enableSystem = true,
 }: ThemeProviderProps) => {
-  const [theme, setThemeState] = useState<Theme>(defaultTheme)
+  return (
+    <JotaiProvider>
+      <ThemeHydrator
+        attribute={attribute}
+        defaultTheme={defaultTheme}
+        disableTransitionOnChange={disableTransitionOnChange}
+        enableSystem={enableSystem}
+      >
+        {children}
+      </ThemeHydrator>
+    </JotaiProvider>
+  )
+}
+
+const ThemeHydrator = ({
+  attribute = 'class',
+  children,
+  defaultTheme = 'system',
+  disableTransitionOnChange = false,
+  enableSystem = true,
+}: ThemeProviderProps) => {
+  useHydrateAtoms([
+    [themeAtom, defaultTheme],
+    [enableSystemAtom, enableSystem],
+    [disableTransitionOnChangeAtom, disableTransitionOnChange],
+  ])
+  const theme = useAtomValue(themeAtom)
+  const setTheme = useSetAtom(themeAtom)
 
   useEffect(() => {
-    const storedTheme = window.localStorage.getItem(storageKey) as Theme | null
-    const initialTheme = storedTheme ?? defaultTheme
-    setThemeState(initialTheme)
-    applyTheme(initialTheme, enableSystem)
-  }, [defaultTheme, enableSystem])
+    const cookieTheme = getThemeCookie(document.cookie)
+    const storedTheme = window.localStorage.getItem(storageKey)
+    const initialTheme =
+      cookieTheme ?? (isTheme(storedTheme) ? storedTheme : defaultTheme)
+    setTheme(initialTheme)
+    applyTheme(initialTheme, enableSystem, disableTransitionOnChange)
+  }, [
+    attribute,
+    defaultTheme,
+    disableTransitionOnChange,
+    enableSystem,
+    setTheme,
+  ])
 
   useEffect(() => {
     if (!enableSystem || theme !== 'system') {
@@ -60,29 +129,18 @@ export const ThemeProvider = ({
     }
 
     const media = window.matchMedia('(prefers-color-scheme: dark)')
-    const handleChange = () => applyTheme('system', true)
+    const handleChange = () =>
+      applyTheme('system', true, disableTransitionOnChange)
     media.addEventListener('change', handleChange)
     return () => media.removeEventListener('change', handleChange)
-  }, [enableSystem, theme])
+  }, [disableTransitionOnChange, enableSystem, theme])
 
-  const setTheme = useCallback(
-    (nextTheme: Theme) => {
-      window.localStorage.setItem(storageKey, nextTheme)
-      setThemeState(nextTheme)
-      applyTheme(nextTheme, enableSystem)
-    },
-    [enableSystem],
-  )
-
-  const value = useMemo(() => ({ setTheme, theme }), [setTheme, theme])
-
-  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  return <>{children}</>
 }
 
 export const useTheme = () => {
-  const context = useContext(ThemeContext)
-  if (!context) {
-    throw new Error('useTheme must be used within ThemeProvider')
+  return {
+    setTheme: useSetAtom(setThemeAtom),
+    theme: useAtomValue(themeAtom),
   }
-  return context
 }

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -54,6 +54,23 @@ const setThemeCookie = (theme: Theme) => {
   document.cookie = `${themeCookieName}=${theme};max-age=31536000;path=/;sameSite=lax`
 }
 
+const getStoredTheme = () => {
+  try {
+    const storedTheme = window.localStorage.getItem(storageKey)
+    return isTheme(storedTheme) ? storedTheme : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const setStoredTheme = (theme: Theme) => {
+  try {
+    window.localStorage.setItem(storageKey, theme)
+  } catch {
+    // Storage can be disabled; the theme cookie still preserves preference.
+  }
+}
+
 const applyTheme = (
   theme: Theme,
   enableSystem: boolean,
@@ -109,9 +126,7 @@ const ThemeHydrator = ({
 
   useLayoutEffect(() => {
     const cookieTheme = getThemeCookie(document.cookie)
-    const storedTheme = window.localStorage.getItem(storageKey)
-    const initialTheme =
-      cookieTheme ?? (isTheme(storedTheme) ? storedTheme : defaultTheme)
+    const initialTheme = cookieTheme ?? getStoredTheme() ?? defaultTheme
     setTheme(initialTheme)
     setResolvedTheme(
       applyTheme(initialTheme, enableSystem, disableTransitionOnChange),
@@ -131,7 +146,7 @@ const ThemeHydrator = ({
     }
 
     if (!skipPersistence) {
-      window.localStorage.setItem(storageKey, theme)
+      setStoredTheme(theme)
       setThemeCookie(theme)
       setResolvedTheme(
         applyTheme(theme, enableSystem, disableTransitionOnChange),

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -3,11 +3,12 @@
 import {
   atom,
   Provider as JotaiProvider,
+  useAtom,
   useAtomValue,
   useSetAtom,
 } from 'jotai'
 import { useHydrateAtoms } from 'jotai/utils'
-import { useEffect, type PropsWithChildren } from 'react'
+import { useEffect, useRef, type PropsWithChildren } from 'react'
 
 import {
   getThemeCookie,
@@ -26,8 +27,6 @@ interface ThemeProviderProps extends PropsWithChildren {
 const storageKey = themeCookieName
 
 const themeAtom = atom<Theme>('system')
-const enableSystemAtom = atom(true)
-const disableTransitionOnChangeAtom = atom(false)
 
 const getSystemTheme = () => {
   return window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -63,15 +62,6 @@ const applyTheme = (
   restoreTransitions?.()
 }
 
-const setThemeAtom = atom(null, (get, set, nextTheme: Theme) => {
-  const enableSystem = get(enableSystemAtom)
-  const disableTransitionOnChange = get(disableTransitionOnChangeAtom)
-  window.localStorage.setItem(storageKey, nextTheme)
-  setThemeCookie(nextTheme)
-  set(themeAtom, nextTheme)
-  applyTheme(nextTheme, enableSystem, disableTransitionOnChange)
-})
-
 export const ThemeProvider = ({
   attribute = 'class',
   children,
@@ -94,19 +84,14 @@ export const ThemeProvider = ({
 }
 
 const ThemeHydrator = ({
-  attribute = 'class',
   children,
   defaultTheme = 'system',
   disableTransitionOnChange = false,
   enableSystem = true,
 }: ThemeProviderProps) => {
-  useHydrateAtoms([
-    [themeAtom, defaultTheme],
-    [enableSystemAtom, enableSystem],
-    [disableTransitionOnChangeAtom, disableTransitionOnChange],
-  ])
-  const theme = useAtomValue(themeAtom)
-  const setTheme = useSetAtom(themeAtom)
+  useHydrateAtoms([[themeAtom, defaultTheme]])
+  const [theme, setTheme] = useAtom(themeAtom)
+  const skipThemeEffect = useRef(true)
 
   useEffect(() => {
     const cookieTheme = getThemeCookie(document.cookie)
@@ -115,24 +100,27 @@ const ThemeHydrator = ({
       cookieTheme ?? (isTheme(storedTheme) ? storedTheme : defaultTheme)
     setTheme(initialTheme)
     applyTheme(initialTheme, enableSystem, disableTransitionOnChange)
-  }, [
-    attribute,
-    defaultTheme,
-    disableTransitionOnChange,
-    enableSystem,
-    setTheme,
-  ])
+  }, [defaultTheme, disableTransitionOnChange, enableSystem, setTheme])
 
   useEffect(() => {
-    if (!enableSystem || theme !== 'system') {
-      return
+    const skipPersistence = skipThemeEffect.current
+    if (skipPersistence) {
+      skipThemeEffect.current = false
     }
 
-    const media = window.matchMedia('(prefers-color-scheme: dark)')
-    const handleChange = () =>
-      applyTheme('system', true, disableTransitionOnChange)
-    media.addEventListener('change', handleChange)
-    return () => media.removeEventListener('change', handleChange)
+    if (!skipPersistence) {
+      window.localStorage.setItem(storageKey, theme)
+      setThemeCookie(theme)
+      applyTheme(theme, enableSystem, disableTransitionOnChange)
+    }
+
+    if (enableSystem && theme === 'system') {
+      const media = window.matchMedia('(prefers-color-scheme: dark)')
+      const handleChange = () =>
+        applyTheme('system', true, disableTransitionOnChange)
+      media.addEventListener('change', handleChange)
+      return () => media.removeEventListener('change', handleChange)
+    }
   }, [disableTransitionOnChange, enableSystem, theme])
 
   return <>{children}</>
@@ -140,7 +128,7 @@ const ThemeHydrator = ({
 
 export const useTheme = () => {
   return {
-    setTheme: useSetAtom(setThemeAtom),
+    setTheme: useSetAtom(themeAtom),
     theme: useAtomValue(themeAtom),
   }
 }

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,10 +1,88 @@
 'use client'
 
 import {
-  ThemeProvider as NextThemesProvider,
-  type ThemeProviderProps,
-} from 'next-themes'
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from 'react'
 
-export const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+export type Theme = 'dark' | 'light' | 'system'
+
+interface ThemeProviderProps extends PropsWithChildren {
+  attribute?: 'class'
+  defaultTheme?: Theme
+  disableTransitionOnChange?: boolean
+  enableSystem?: boolean
+}
+
+interface ThemeContextValue {
+  setTheme: (theme: Theme) => void
+  theme: Theme
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+const storageKey = 'theme'
+
+const getSystemTheme = () => {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
+
+const applyTheme = (theme: Theme, enableSystem: boolean) => {
+  const resolvedTheme =
+    theme === 'system' && enableSystem ? getSystemTheme() : theme
+  document.documentElement.classList.toggle('dark', resolvedTheme === 'dark')
+}
+
+export const ThemeProvider = ({
+  children,
+  defaultTheme = 'system',
+  enableSystem = true,
+}: ThemeProviderProps) => {
+  const [theme, setThemeState] = useState<Theme>(defaultTheme)
+
+  useEffect(() => {
+    const storedTheme = window.localStorage.getItem(storageKey) as Theme | null
+    const initialTheme = storedTheme ?? defaultTheme
+    setThemeState(initialTheme)
+    applyTheme(initialTheme, enableSystem)
+  }, [defaultTheme, enableSystem])
+
+  useEffect(() => {
+    if (!enableSystem || theme !== 'system') {
+      return
+    }
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    const handleChange = () => applyTheme('system', true)
+    media.addEventListener('change', handleChange)
+    return () => media.removeEventListener('change', handleChange)
+  }, [enableSystem, theme])
+
+  const setTheme = useCallback(
+    (nextTheme: Theme) => {
+      window.localStorage.setItem(storageKey, nextTheme)
+      setThemeState(nextTheme)
+      applyTheme(nextTheme, enableSystem)
+    },
+    [enableSystem],
+  )
+
+  const value = useMemo(() => ({ setTheme, theme }), [setTheme, theme])
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider')
+  }
+  return context
 }

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,13 +1,6 @@
 'use client'
 
-import {
-  atom,
-  Provider as JotaiProvider,
-  useAtom,
-  useAtomValue,
-  useSetAtom,
-} from 'jotai'
-import { useHydrateAtoms } from 'jotai/utils'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import {
   useEffect,
   useLayoutEffect,
@@ -15,6 +8,7 @@ import {
   type PropsWithChildren,
 } from 'react'
 
+import { resolvedThemeAtom, themeAtom } from '~/components/theme-atoms'
 import {
   getThemeCookie,
   isTheme,
@@ -32,9 +26,6 @@ interface ThemeProviderProps extends PropsWithChildren {
 const storageKey = themeCookieName
 const useIsomorphicLayoutEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect
-
-const themeAtom = atom<Theme>('system')
-const resolvedThemeAtom = atom<'dark' | 'light'>('light')
 
 const getSystemTheme = () => {
   return window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -95,33 +86,12 @@ const applyTheme = (
 }
 
 export const ThemeProvider = ({
-  attribute = 'class',
+  attribute: _attribute = 'class',
   children,
   defaultTheme = 'system',
   disableTransitionOnChange = false,
   enableSystem = true,
 }: ThemeProviderProps) => {
-  return (
-    <JotaiProvider>
-      <ThemeHydrator
-        attribute={attribute}
-        defaultTheme={defaultTheme}
-        disableTransitionOnChange={disableTransitionOnChange}
-        enableSystem={enableSystem}
-      >
-        {children}
-      </ThemeHydrator>
-    </JotaiProvider>
-  )
-}
-
-const ThemeHydrator = ({
-  children,
-  defaultTheme = 'system',
-  disableTransitionOnChange = false,
-  enableSystem = true,
-}: ThemeProviderProps) => {
-  useHydrateAtoms([[themeAtom, defaultTheme]])
   const [theme, setTheme] = useAtom(themeAtom)
   const setResolvedTheme = useSetAtom(resolvedThemeAtom)
   const skipThemeEffect = useRef(true)

--- a/src/components/theme-runtime.tsx
+++ b/src/components/theme-runtime.tsx
@@ -1,12 +1,7 @@
 'use client'
 
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  type PropsWithChildren,
-} from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 
 import { resolvedThemeAtom, themeAtom } from '~/components/theme-atoms'
 import {
@@ -16,8 +11,7 @@ import {
   type Theme,
 } from '~/lib/theme'
 
-interface ThemeProviderProps extends PropsWithChildren {
-  attribute?: 'class'
+interface ThemeRuntimeOptions {
   defaultTheme?: Theme
   disableTransitionOnChange?: boolean
   enableSystem?: boolean
@@ -85,13 +79,11 @@ const applyTheme = (
   return resolvedTheme
 }
 
-export const ThemeProvider = ({
-  attribute: _attribute = 'class',
-  children,
+export const useThemeRuntime = ({
   defaultTheme = 'system',
   disableTransitionOnChange = false,
   enableSystem = true,
-}: ThemeProviderProps) => {
+}: ThemeRuntimeOptions = {}) => {
   const [theme, setTheme] = useAtom(themeAtom)
   const setResolvedTheme = useSetAtom(resolvedThemeAtom)
   const skipThemeEffect = useRef(true)
@@ -136,8 +128,11 @@ export const ThemeProvider = ({
       return () => media.removeEventListener('change', handleChange)
     }
   }, [disableTransitionOnChange, enableSystem, setResolvedTheme, theme])
+}
 
-  return <>{children}</>
+export const ThemeRuntime = (options: ThemeRuntimeOptions) => {
+  useThemeRuntime(options)
+  return null
 }
 
 export const useTheme = () => {

--- a/src/hooks/use-i18n-pathname.ts
+++ b/src/hooks/use-i18n-pathname.ts
@@ -45,7 +45,11 @@ const restoreHistory = () => {
 const subscribe = (onStoreChange: () => void) => {
   patchHistory()
   subscribers += 1
+  let active = true
   queueMicrotask(() => {
+    if (!active) {
+      return
+    }
     hydrated = true
     onStoreChange()
   })
@@ -54,6 +58,7 @@ const subscribe = (onStoreChange: () => void) => {
   return () => {
     window.removeEventListener('popstate', onStoreChange)
     window.removeEventListener(locationChangeEvent, onStoreChange)
+    active = false
     subscribers -= 1
     restoreHistory()
   }

--- a/src/hooks/use-i18n-pathname.ts
+++ b/src/hooks/use-i18n-pathname.ts
@@ -2,6 +2,7 @@ import { useSyncExternalStore } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const locationChangeEvent = 'locationchange'
+let hydrated = false
 
 const patchHistory = () => {
   const historyWithPatchState = window.history as History & {
@@ -33,6 +34,10 @@ const patchHistory = () => {
 
 const subscribe = (onStoreChange: () => void) => {
   patchHistory()
+  queueMicrotask(() => {
+    hydrated = true
+    onStoreChange()
+  })
   window.addEventListener('popstate', onStoreChange)
   window.addEventListener(locationChangeEvent, onStoreChange)
   return () => {
@@ -41,7 +46,7 @@ const subscribe = (onStoreChange: () => void) => {
   }
 }
 
-const getPathname = () => window.location.pathname
+const getPathname = () => (hydrated ? window.location.pathname : undefined)
 
 const getServerSnapshot = () => undefined
 

--- a/src/hooks/use-i18n-pathname.ts
+++ b/src/hooks/use-i18n-pathname.ts
@@ -1,8 +1,56 @@
-import { usePathname } from 'next/navigation'
+import { useSyncExternalStore } from 'react'
 import { useTranslation } from 'react-i18next'
 
+const locationChangeEvent = 'locationchange'
+
+const patchHistory = () => {
+  const historyWithPatchState = window.history as History & {
+    __poiLocationPatched?: boolean
+  }
+  if (historyWithPatchState.__poiLocationPatched) {
+    return
+  }
+
+  const dispatchLocationChange = () => {
+    window.dispatchEvent(new Event(locationChangeEvent))
+  }
+  const pushState = window.history.pushState.bind(window.history)
+  const replaceState = window.history.replaceState.bind(window.history)
+  window.history.pushState = function pushStateWithLocationChange(...args) {
+    const result = pushState.apply(this, args)
+    dispatchLocationChange()
+    return result
+  }
+  window.history.replaceState = function replaceStateWithLocationChange(
+    ...args
+  ) {
+    const result = replaceState.apply(this, args)
+    dispatchLocationChange()
+    return result
+  }
+  historyWithPatchState.__poiLocationPatched = true
+}
+
+const subscribe = (onStoreChange: () => void) => {
+  patchHistory()
+  window.addEventListener('popstate', onStoreChange)
+  window.addEventListener(locationChangeEvent, onStoreChange)
+  return () => {
+    window.removeEventListener('popstate', onStoreChange)
+    window.removeEventListener(locationChangeEvent, onStoreChange)
+  }
+}
+
+const getPathname = () => window.location.pathname
+
+const getServerSnapshot = () => '/'
+
 export const useI18nPathname = () => {
-  const pathname = usePathname()
+  const pathname = useSyncExternalStore(
+    subscribe,
+    getPathname,
+    getServerSnapshot,
+  )
   const { i18n } = useTranslation()
 
   if (pathname === `/${i18n.language}`) {

--- a/src/hooks/use-i18n-pathname.ts
+++ b/src/hooks/use-i18n-pathname.ts
@@ -3,37 +3,48 @@ import { useTranslation } from 'react-i18next'
 
 const locationChangeEvent = 'locationchange'
 let hydrated = false
+let subscribers = 0
+let originalPushState: History['pushState'] | undefined
+let originalReplaceState: History['replaceState'] | undefined
 
 const patchHistory = () => {
-  const historyWithPatchState = window.history as History & {
-    __poiLocationPatched?: boolean
-  }
-  if (historyWithPatchState.__poiLocationPatched) {
+  if (originalPushState || originalReplaceState) {
     return
   }
 
   const dispatchLocationChange = () => {
     window.dispatchEvent(new Event(locationChangeEvent))
   }
-  const pushState = window.history.pushState.bind(window.history)
-  const replaceState = window.history.replaceState.bind(window.history)
+  originalPushState = window.history.pushState.bind(window.history)
+  originalReplaceState = window.history.replaceState.bind(window.history)
   window.history.pushState = function pushStateWithLocationChange(...args) {
-    const result = pushState.apply(this, args)
+    const result = originalPushState!(...args)
     dispatchLocationChange()
     return result
   }
   window.history.replaceState = function replaceStateWithLocationChange(
     ...args
   ) {
-    const result = replaceState.apply(this, args)
+    const result = originalReplaceState!(...args)
     dispatchLocationChange()
     return result
   }
-  historyWithPatchState.__poiLocationPatched = true
+}
+
+const restoreHistory = () => {
+  if (subscribers > 0 || !originalPushState || !originalReplaceState) {
+    return
+  }
+
+  window.history.pushState = originalPushState
+  window.history.replaceState = originalReplaceState
+  originalPushState = undefined
+  originalReplaceState = undefined
 }
 
 const subscribe = (onStoreChange: () => void) => {
   patchHistory()
+  subscribers += 1
   queueMicrotask(() => {
     hydrated = true
     onStoreChange()
@@ -43,6 +54,8 @@ const subscribe = (onStoreChange: () => void) => {
   return () => {
     window.removeEventListener('popstate', onStoreChange)
     window.removeEventListener(locationChangeEvent, onStoreChange)
+    subscribers -= 1
+    restoreHistory()
   }
 }
 

--- a/src/hooks/use-i18n-pathname.ts
+++ b/src/hooks/use-i18n-pathname.ts
@@ -43,7 +43,7 @@ const subscribe = (onStoreChange: () => void) => {
 
 const getPathname = () => window.location.pathname
 
-const getServerSnapshot = () => '/'
+const getServerSnapshot = () => undefined
 
 export const useI18nPathname = () => {
   const pathname = useSyncExternalStore(
@@ -52,6 +52,10 @@ export const useI18nPathname = () => {
     getServerSnapshot,
   )
   const { i18n } = useTranslation()
+
+  if (!pathname) {
+    return undefined
+  }
 
   if (pathname === `/${i18n.language}`) {
     return '/'

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,9 +1,15 @@
-export type Theme = 'dark' | 'light' | 'system'
+import { z } from 'zod'
+
+export const themeSchema = z.enum(['dark', 'light', 'system'])
+
+export const colorSchemeSchema = z.enum(['dark', 'light'])
+
+export type Theme = z.infer<typeof themeSchema>
 
 export const themeCookieName = 'theme'
 
 export const isTheme = (value: string | null | undefined): value is Theme => {
-  return value === 'dark' || value === 'light' || value === 'system'
+  return themeSchema.safeParse(value).success
 }
 
 export const parseCookieString = (cookie: string) => {
@@ -26,16 +32,14 @@ export const getThemeCookie = (cookie: string | null | undefined) => {
     return undefined
   }
   const theme = parseCookieString(cookie)[themeCookieName]
-  return isTheme(theme) ? theme : undefined
+  return themeSchema.safeParse(theme).data
 }
 
 export const getPreferredColorScheme = (headers: Headers) => {
   const preferredColorScheme = headers
     .get('Sec-CH-Prefers-Color-Scheme')
     ?.replace(/^"|"$/g, '')
-  return preferredColorScheme === 'dark' || preferredColorScheme === 'light'
-    ? preferredColorScheme
-    : undefined
+  return colorSchemeSchema.safeParse(preferredColorScheme).data
 }
 
 export const resolveServerTheme = (headers: Headers) => {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,30 @@
+export type Theme = 'dark' | 'light' | 'system'
+
+export const themeCookieName = 'theme'
+
+export const isTheme = (value: string | null | undefined): value is Theme => {
+  return value === 'dark' || value === 'light' || value === 'system'
+}
+
+export const parseCookieString = (cookie: string) => {
+  const cookies = Object.create(null) as Record<string, string>
+  for (const entry of cookie.split(';')) {
+    const [key, ...value] = entry.trim().split('=')
+    if (key) {
+      try {
+        cookies[key] = decodeURIComponent(value.join('='))
+      } catch {
+        // Ignore malformed cookie values instead of failing request rendering.
+      }
+    }
+  }
+  return cookies
+}
+
+export const getThemeCookie = (cookie: string | null | undefined) => {
+  if (!cookie) {
+    return undefined
+  }
+  const theme = parseCookieString(cookie)[themeCookieName]
+  return isTheme(theme) ? theme : undefined
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -28,3 +28,25 @@ export const getThemeCookie = (cookie: string | null | undefined) => {
   const theme = parseCookieString(cookie)[themeCookieName]
   return isTheme(theme) ? theme : undefined
 }
+
+export const getPreferredColorScheme = (headers: Headers) => {
+  const preferredColorScheme = headers
+    .get('Sec-CH-Prefers-Color-Scheme')
+    ?.replace(/^"|"$/g, '')
+  return preferredColorScheme === 'dark' || preferredColorScheme === 'light'
+    ? preferredColorScheme
+    : undefined
+}
+
+export const resolveServerTheme = (headers: Headers) => {
+  const theme = getThemeCookie(headers.get('Cookie'))
+  if (theme === 'dark' || theme === 'light') {
+    return theme
+  }
+
+  return getPreferredColorScheme(headers)
+}
+
+export const getServerThemePreference = (headers: Headers): Theme => {
+  return getThemeCookie(headers.get('Cookie')) ?? 'system'
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,6 +46,28 @@ const poiHeaders = [
 const clientHintValues =
   'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile, Sec-CH-Prefers-Color-Scheme'
 
+const appendVary = (headers: Headers, value: string) => {
+  const current = headers.get('Vary')
+  if (!current) {
+    headers.set('Vary', value)
+    return
+  }
+  if (current.trim() === '*') {
+    return
+  }
+
+  const values = new Set(
+    current
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  )
+  value.split(',').forEach((entry) => {
+    values.add(entry.trim())
+  })
+  headers.set('Vary', [...values].join(', '))
+}
+
 export function middleware(request: NextRequest) {
   const localize = shouldLocalize(request.nextUrl.pathname)
   let resp: NextResponse
@@ -62,7 +84,7 @@ export function middleware(request: NextRequest) {
   if (localize) {
     resp.headers.set('Accept-CH', clientHintValues)
     resp.headers.set('Critical-CH', clientHintValues)
-    resp.headers.set('Vary', clientHintValues)
+    appendVary(resp.headers, clientHintValues)
   }
 
   return resp

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,26 +24,6 @@ const shouldLocalize = (pathname: string): boolean => {
   return true
 }
 
-// FIXME: CF Pages does not always honor next.config.js headers config
-// Check if this is required when miragted to worker
-const clientHintHeaders = [
-  {
-    key: 'Accept-CH',
-    value:
-      'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile, Sec-CH-Prefers-Color-Scheme',
-  },
-  {
-    key: 'Critical-CH',
-    value:
-      'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile, Sec-CH-Prefers-Color-Scheme',
-  },
-  {
-    key: 'Vary',
-    value:
-      'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile, Sec-CH-Prefers-Color-Scheme',
-  },
-]
-
 const poiHeaders = [
   {
     key: 'X-Poi-Codename',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,17 +30,17 @@ const clientHintHeaders = [
   {
     key: 'Accept-CH',
     value:
-      'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile',
+      'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile, Sec-CH-Prefers-Color-Scheme',
   },
   {
     key: 'Critical-CH',
     value:
-      'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile',
+      'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile, Sec-CH-Prefers-Color-Scheme',
   },
   {
     key: 'Vary',
     value:
-      'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile',
+      'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile, Sec-CH-Prefers-Color-Scheme',
   },
 ]
 
@@ -64,7 +64,7 @@ const poiHeaders = [
 ]
 
 const clientHintValues =
-  'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile'
+  'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile, Sec-CH-Prefers-Color-Scheme'
 
 export function middleware(request: NextRequest) {
   const localize = shouldLocalize(request.nextUrl.pathname)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -16,7 +16,7 @@ import { FooterClient } from '~/components/footer-client'
 import { Header } from '~/components/header'
 import { I18nProvider } from '~/components/i18n-provider'
 import { JotaiRootProvider } from '~/components/jotai-provider'
-import { ThemeProvider } from '~/components/theme-provider'
+import { ThemeRuntime } from '~/components/theme-runtime'
 import { defaultLocale, isSupportedLocale } from '~/lib/i18n-routing'
 import { isMobileDevice } from '~/lib/target'
 import { getServerThemePreference, resolveServerTheme } from '~/lib/theme'
@@ -166,25 +166,23 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           initialResolvedTheme={theme ?? 'light'}
           initialTheme={themePreference}
         >
-          <ThemeProvider
-            attribute="class"
+          <ThemeRuntime
             defaultTheme={themePreference}
             enableSystem
             disableTransitionOnChange
+          />
+          <DesktopBackground initialEnabled={!isMobile} />
+          <I18nProvider
+            locale={locale}
+            namespaces={['common']}
+            resources={resources}
           >
-            <DesktopBackground initialEnabled={!isMobile} />
-            <I18nProvider
-              locale={locale}
-              namespaces={['common']}
-              resources={resources}
-            >
-              <div className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">
-                <Header />
-                {children}
-                <FooterClient />
-              </div>
-            </I18nProvider>
-          </ThemeProvider>
+            <div className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">
+              <Header />
+              {children}
+              <FooterClient />
+            </div>
+          </I18nProvider>
         </JotaiRootProvider>
         <Scripts />
       </body>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,13 +9,13 @@ import {
 import { createServerOnlyFn } from '@tanstack/react-start'
 import { getRequestHeaders } from '@tanstack/react-start/server'
 import type { Resource } from 'i18next'
-import { Provider as JotaiProvider } from 'jotai'
 
 import '~/styles/globals.css'
 import { DesktopBackground } from '~/components/desktop-background'
 import { FooterClient } from '~/components/footer-client'
 import { Header } from '~/components/header'
 import { I18nProvider } from '~/components/i18n-provider'
+import { JotaiRootProvider } from '~/components/jotai-provider'
 import { ThemeProvider } from '~/components/theme-provider'
 import { defaultLocale, isSupportedLocale } from '~/lib/i18n-routing'
 import { isMobileDevice } from '~/lib/target'
@@ -162,25 +162,30 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme={themePreference}
-          enableSystem
-          disableTransitionOnChange
+        <JotaiRootProvider
+          initialResolvedTheme={theme ?? 'light'}
+          initialTheme={themePreference}
         >
-          <DesktopBackground initialEnabled={!isMobile} />
-          <I18nProvider
-            locale={locale}
-            namespaces={['common']}
-            resources={resources}
+          <ThemeProvider
+            attribute="class"
+            defaultTheme={themePreference}
+            enableSystem
+            disableTransitionOnChange
           >
-            <div className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">
-              <Header />
-              <JotaiProvider>{children}</JotaiProvider>
-              <FooterClient />
-            </div>
-          </I18nProvider>
-        </ThemeProvider>
+            <DesktopBackground initialEnabled={!isMobile} />
+            <I18nProvider
+              locale={locale}
+              namespaces={['common']}
+              resources={resources}
+            >
+              <div className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">
+                <Header />
+                {children}
+                <FooterClient />
+              </div>
+            </I18nProvider>
+          </ThemeProvider>
+        </JotaiRootProvider>
         <Scripts />
       </body>
     </html>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,10 +6,32 @@ import {
   createRootRouteWithContext,
   useRouterState,
 } from '@tanstack/react-router'
+import type { Resource } from 'i18next'
 import { Provider as JotaiProvider } from 'jotai'
 
 import '~/styles/globals.css'
+import { Background } from '~/components/background'
+import { FooterClient } from '~/components/footer-client'
+import { Header } from '~/components/header'
+import { I18nProvider } from '~/components/i18n-provider'
+import { ThemeProvider } from '~/components/theme-provider'
 import { defaultLocale, isSupportedLocale } from '~/lib/i18n-routing'
+import { cn } from '~/lib/utils'
+import enCommon from '~/locales/en/common.json'
+import frCommon from '~/locales/fr/common.json'
+import jaCommon from '~/locales/ja/common.json'
+import koCommon from '~/locales/ko/common.json'
+import zhHansCommon from '~/locales/zh-Hans/common.json'
+import zhHantCommon from '~/locales/zh-Hant/common.json'
+
+const resources = {
+  en: { common: enCommon },
+  fr: { common: frCommon },
+  ja: { common: jaCommon },
+  ko: { common: koCommon },
+  'zh-Hans': { common: zhHansCommon },
+  'zh-Hant': { common: zhHantCommon },
+} satisfies Resource
 
 export interface TanStackRouterContext {
   env?: {
@@ -41,10 +63,7 @@ export const Route = createRootRouteWithContext<TanStackRouterContext>()({
           'Scalable KanColle browser and tool, for Windows, macOS and Linux. 一个可扩展的舰队Collectionブラウザ。拡張可能な艦隊これくしょんブラウザ。',
       },
     ],
-    links: [
-      { rel: 'icon', href: '/favicon.ico' },
-      { rel: 'stylesheet', href: '/fonts/plex-sans/IBMPlexSans-Regular.css' },
-    ],
+    links: [{ rel: 'icon', href: '/favicon.ico' }],
   }),
   shellComponent: RootDocument,
 })
@@ -65,12 +84,69 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   })
 
   return (
-    <html lang={locale}>
+    <html
+      lang={locale}
+      className={cn({
+        'font-ja': locale === 'ja',
+        'font-zh-hant': locale === 'zh-Hant',
+        'font-zh-hans': locale === 'zh-Hans',
+        'font-ko': locale === 'ko',
+      })}
+      suppressHydrationWarning
+    >
       <head>
+        <link
+          href="/fonts/plex-sans/IBMPlexSans-Regular.css"
+          rel="stylesheet"
+        />
+        {locale === 'ja' && (
+          <link
+            href="/fonts/plex-sans-jp/IBMPlexSansJP-Regular.css"
+            rel="stylesheet"
+          />
+        )}
+        {locale === 'zh-Hant' && (
+          <link
+            href="/fonts/plex-sans-tc/IBMPlexSansTC-Regular.css"
+            rel="stylesheet"
+          />
+        )}
+        {locale === 'zh-Hans' && (
+          <link
+            href="/fonts/plex-sans-sc/IBMPlexSansSC-Regular.css"
+            rel="stylesheet"
+          />
+        )}
+        {locale === 'ko' && (
+          <link
+            href="/fonts/plex-sans-kr/IBMPlexSansKR-Regular.css"
+            rel="stylesheet"
+          />
+        )}
         <HeadContent />
       </head>
       <body>
-        <JotaiProvider>{children}</JotaiProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <div className="hidden md:block">
+            <Background />
+          </div>
+          <I18nProvider
+            locale={locale}
+            namespaces={['common']}
+            resources={resources}
+          >
+            <div className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">
+              <Header />
+              <JotaiProvider>{children}</JotaiProvider>
+              <FooterClient />
+            </div>
+          </I18nProvider>
+        </ThemeProvider>
         <Scripts />
       </body>
     </html>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,16 +6,20 @@ import {
   createRootRouteWithContext,
   useRouterState,
 } from '@tanstack/react-router'
+import { createServerOnlyFn } from '@tanstack/react-start'
+import { getRequestHeaders } from '@tanstack/react-start/server'
 import type { Resource } from 'i18next'
 import { Provider as JotaiProvider } from 'jotai'
 
 import '~/styles/globals.css'
-import { Background } from '~/components/background'
+import { DesktopBackground } from '~/components/desktop-background'
 import { FooterClient } from '~/components/footer-client'
 import { Header } from '~/components/header'
 import { I18nProvider } from '~/components/i18n-provider'
 import { ThemeProvider } from '~/components/theme-provider'
 import { defaultLocale, isSupportedLocale } from '~/lib/i18n-routing'
+import { isMobileDevice } from '~/lib/target'
+import { getThemeCookie } from '~/lib/theme'
 import { cn } from '~/lib/utils'
 import enCommon from '~/locales/en/common.json'
 import frCommon from '~/locales/fr/common.json'
@@ -33,6 +37,32 @@ const resources = {
   'zh-Hant': { common: zhHantCommon },
 } satisfies Resource
 
+const getCurrentRequestHeaders = createServerOnlyFn(
+  () => new Headers(getRequestHeaders()),
+)
+
+const getThemeRequestCookie = (context: TanStackRouterContext) => {
+  const requestHeaders =
+    context.serverContext?.requestHeaders ?? context.requestHeaders
+  if (requestHeaders) {
+    return new Headers(requestHeaders).get('Cookie')
+  }
+  return typeof document === 'undefined'
+    ? getCurrentRequestHeaders().get('Cookie')
+    : document.cookie
+}
+
+const getCurrentRequestHeadersForRoot = (context: TanStackRouterContext) => {
+  const requestHeaders =
+    context.serverContext?.requestHeaders ?? context.requestHeaders
+  if (requestHeaders) {
+    return new Headers(requestHeaders)
+  }
+  return typeof document === 'undefined'
+    ? getCurrentRequestHeaders()
+    : new Headers()
+}
+
 export interface TanStackRouterContext {
   env?: {
     TANSTACK_TEST_POI_VERSIONS?: string
@@ -47,6 +77,13 @@ export interface TanStackRouterContext {
 }
 
 export const Route = createRootRouteWithContext<TanStackRouterContext>()({
+  loader: async ({ context }) => {
+    const headers = getCurrentRequestHeadersForRoot(context)
+    return {
+      isMobile: await isMobileDevice(headers),
+      theme: getThemeCookie(getThemeRequestCookie(context)),
+    }
+  },
   head: () => ({
     meta: [
       { charSet: 'utf-8' },
@@ -69,6 +106,7 @@ export const Route = createRootRouteWithContext<TanStackRouterContext>()({
 })
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  const { isMobile, theme } = Route.useLoaderData()
   const locale = useRouterState({
     select: (state) => {
       const routeLocale = state.matches
@@ -87,6 +125,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
     <html
       lang={locale}
       className={cn({
+        dark: theme === 'dark',
         'font-ja': locale === 'ja',
         'font-zh-hant': locale === 'zh-Hant',
         'font-zh-hans': locale === 'zh-Hans',
@@ -128,13 +167,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       <body>
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme={theme ?? 'system'}
           enableSystem
           disableTransitionOnChange
         >
-          <div className="hidden md:block">
-            <Background />
-          </div>
+          <DesktopBackground initialEnabled={!isMobile} />
           <I18nProvider
             locale={locale}
             namespaces={['common']}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -19,7 +19,7 @@ import { I18nProvider } from '~/components/i18n-provider'
 import { ThemeProvider } from '~/components/theme-provider'
 import { defaultLocale, isSupportedLocale } from '~/lib/i18n-routing'
 import { isMobileDevice } from '~/lib/target'
-import { getThemeCookie } from '~/lib/theme'
+import { getServerThemePreference, resolveServerTheme } from '~/lib/theme'
 import { cn } from '~/lib/utils'
 import enCommon from '~/locales/en/common.json'
 import frCommon from '~/locales/fr/common.json'
@@ -40,17 +40,6 @@ const resources = {
 const getCurrentRequestHeaders = createServerOnlyFn(
   () => new Headers(getRequestHeaders()),
 )
-
-const getThemeRequestCookie = (context: TanStackRouterContext) => {
-  const requestHeaders =
-    context.serverContext?.requestHeaders ?? context.requestHeaders
-  if (requestHeaders) {
-    return new Headers(requestHeaders).get('Cookie')
-  }
-  return typeof document === 'undefined'
-    ? getCurrentRequestHeaders().get('Cookie')
-    : document.cookie
-}
 
 const getCurrentRequestHeadersForRoot = (context: TanStackRouterContext) => {
   const requestHeaders =
@@ -81,7 +70,8 @@ export const Route = createRootRouteWithContext<TanStackRouterContext>()({
     const headers = getCurrentRequestHeadersForRoot(context)
     return {
       isMobile: await isMobileDevice(headers),
-      theme: getThemeCookie(getThemeRequestCookie(context)),
+      theme: resolveServerTheme(headers),
+      themePreference: getServerThemePreference(headers),
     }
   },
   head: () => ({
@@ -106,7 +96,7 @@ export const Route = createRootRouteWithContext<TanStackRouterContext>()({
 })
 
 function RootDocument({ children }: { children: React.ReactNode }) {
-  const { isMobile, theme } = Route.useLoaderData()
+  const { isMobile, theme, themePreference } = Route.useLoaderData()
   const locale = useRouterState({
     select: (state) => {
       const routeLocale = state.matches
@@ -167,7 +157,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       <body>
         <ThemeProvider
           attribute="class"
-          defaultTheme={theme ?? 'system'}
+          defaultTheme={themePreference}
           enableSystem
           disableTransitionOnChange
         >

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -115,7 +115,6 @@ function RootDocument({ children }: { children: React.ReactNode }) {
     <html
       lang={locale}
       className={cn({
-        dark: theme === 'dark',
         'font-ja': locale === 'ja',
         'font-zh-hant': locale === 'zh-Hant',
         'font-zh-hans': locale === 'zh-Hans',
@@ -124,6 +123,14 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       suppressHydrationWarning
     >
       <head>
+        {theme === 'dark' && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html:
+                "document.documentElement.classList.add('dark');document.currentScript.remove();",
+            }}
+          />
+        )}
         <link
           href="/fonts/plex-sans/IBMPlexSans-Regular.css"
           rel="stylesheet"

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -36,7 +36,7 @@ type StartHandlerWithContext = (
 ) => Promise<Response>
 
 const clientHintValues =
-  'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile'
+  'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile, Sec-CH-Prefers-Color-Scheme'
 
 const buildDate = process.env.BUILD_DATE ?? 'development'
 const commitHash = process.env.COMMIT_HASH ?? 'development'


### PR DESCRIPTION
Follow-up for #489.

## Summary

- Replaces shared header/language/theme/background usage of `next/link`, `next/navigation`, and `next-themes` with framework-neutral helpers/providers.
- Wires the TanStack root shell with i18n, theme, header, footer, background, fonts, and per-request Jotai provider support.
- Keeps the Next server layout safe by splitting a client-only footer wrapper from the server-safe footer renderer.
- Adds TanStack e2e coverage for header links, logo asset shape, language switching/cookie behavior, pushState pathname updates, and theme switching.

## Validation

- `pnpm run lint:next` (passes with existing middleware warning)
- `pnpm run typecheck`
- `pnpm run test:unit`
- `pnpm run check:tanstack-imports`
- `pnpm run test:e2e:tanstack`
- `pnpm run test:e2e:next`
- `pnpm run build:tanstack` without `TANSTACK_TEST_POI_VERSIONS`; verified no fixture version strings in `dist/server/**/*.js`