### PR TITLE
ci: switch OpenCode review to GLM-5.2

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode-go/deepseek-v4-pro
+          model: opencode-go/glm-5.2
           use_github_token: true
           prompt: |
             Review this pull request as a senior maintainer.


### PR DESCRIPTION
## Summary
- switch the OpenCode PR review workflow from DeepSeek V4 Pro to GLM-5.2
- keep the existing OpenCode Go provider and review workflow behavior unchanged

## Validation
- prettier --check .github/workflows/opencode-review.yml
- git diff --check