### PR TITLE
Add TanStack robustness checks

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,6 +29,8 @@ jobs:
         run: corepack pnpm run test:unit
       - name: Check TanStack imports
         run: corepack pnpm run check:tanstack-imports
+      - name: Check TanStack build output
+        run: corepack pnpm run check:tanstack-output
       - name: Run Playwright tests
         run: corepack pnpm run test:e2e:next
       - name: Run TanStack Playwright tests

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:next": "eslint src specs specs-tanstack next.config.js vite.config.ts vitest.config.ts playwright.config.ts playwright.next.config.ts playwright.tanstack.config.ts tailwind.config.ts --ext .js,.cjs,.ts,.tsx --ignore-pattern next-env.d.ts",
     "lint:tanstack": "eslint src/routes src/router.tsx src/worker.ts src/components/ui src/lib/fetch-poi-versions.ts src/lib/route-handlers.ts src/lib/social-image.ts src/lib/utils.ts specs-tanstack vite.config.ts vitest.config.ts playwright.tanstack.config.ts --ext .js,.ts,.tsx",
     "check:tanstack-imports": "node scripts/check-tanstack-imports.mjs",
+    "check:tanstack-output": "node scripts/check-tanstack-output.mjs",
     "typecheck": "wrangler types --config wrangler.toml --env-interface CloudflareEnv cloudflare-env.d.ts && tsc --noEmit",
     "typecheck:next": "tsc --noEmit",
     "test:unit": "vitest run --config vitest.config.ts",

--- a/scripts/check-tanstack-output.mjs
+++ b/scripts/check-tanstack-output.mjs
@@ -1,0 +1,163 @@
+import { existsSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const distRoot = path.resolve('dist')
+const clientDir = path.join(distRoot, 'client')
+const serverDir = path.join(distRoot, 'server')
+const wranglerConfigPath = path.join(serverDir, 'wrangler.json')
+
+const KiB = 1024
+const budgets = {
+  maxClientEntryKiB: 820,
+  maxClientChunkKiB: 320,
+  maxClientJsTotalKiB: 1_500,
+  maxServerEntryKiB: 725,
+  maxServerChunkKiB: 980,
+}
+
+const forbiddenWorkerPatterns = [
+  { label: 'OpenNext runtime marker', pattern: /open-next|opennext/i },
+  { label: 'Next.js runtime import marker', pattern: /next\/(?:server|navigation|headers|og)/ },
+]
+
+const forbiddenClientPatterns = [
+  ...forbiddenWorkerPatterns,
+  { label: 'Node.js client import marker', pattern: /from\s*["']node:|require\(["']node:/ },
+]
+
+const failures = []
+
+const fail = (message) => failures.push(message)
+
+const collectFiles = async (dir) => {
+  if (!existsSync(dir)) {
+    return []
+  }
+
+  const entries = await readdir(dir, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        return collectFiles(fullPath)
+      }
+      return [fullPath]
+    }),
+  )
+  return files.flat()
+}
+
+const formatKiB = (bytes) => `${(bytes / KiB).toFixed(1)} KiB`
+
+const assertBudget = (label, bytes, maxKiB) => {
+  const maxBytes = maxKiB * KiB
+  if (bytes > maxBytes) {
+    fail(`${label} is ${formatKiB(bytes)}, above budget ${maxKiB} KiB`)
+  }
+}
+
+if (!existsSync(wranglerConfigPath)) {
+  fail('Missing dist/server/wrangler.json. Run `pnpm run build` first.')
+} else {
+  const wranglerConfig = JSON.parse(await readFile(wranglerConfigPath, 'utf8'))
+  if (wranglerConfig.name !== 'poi-web-kai') {
+    fail(`Expected Worker name poi-web-kai, got ${wranglerConfig.name}`)
+  }
+  if (wranglerConfig.main !== 'index.js') {
+    fail(`Expected Worker main index.js, got ${wranglerConfig.main}`)
+  }
+  if (wranglerConfig.assets?.directory !== '../client') {
+    fail(`Expected assets.directory ../client, got ${wranglerConfig.assets?.directory}`)
+  }
+  const routePatterns = new Set(
+    (wranglerConfig.routes ?? []).map((route) => route.pattern),
+  )
+  for (const pattern of ['poi.moe', 'update.poi.moe']) {
+    if (!routePatterns.has(pattern)) {
+      fail(`Missing production route ${pattern} in generated Wrangler config`)
+    }
+  }
+}
+
+const clientFiles = await collectFiles(clientDir)
+const serverFiles = await collectFiles(serverDir)
+const allDistFiles = [...clientFiles, ...serverFiles]
+const sourceMaps = allDistFiles.filter((file) => file.endsWith('.map'))
+if (sourceMaps.length > 0) {
+  fail(`Production build emitted ${sourceMaps.length} sourcemaps without Sentry upload`)
+}
+
+const clientJs = clientFiles.filter((file) => file.endsWith('.js'))
+const serverJs = serverFiles.filter((file) => file.endsWith('.js'))
+const clientEntry = clientJs.find((file) => /[\\/]assets[\\/]index-[^\\/]+\.js$/.test(file))
+const serverEntry = path.join(serverDir, 'index.js')
+
+if (!clientEntry) {
+  fail('Missing client entry asset dist/client/assets/index-*.js')
+} else {
+  assertBudget('Client entry chunk', (await readFile(clientEntry)).byteLength, budgets.maxClientEntryKiB)
+}
+
+if (!existsSync(serverEntry)) {
+  fail('Missing server entry dist/server/index.js')
+} else {
+  assertBudget('Server entry chunk', (await readFile(serverEntry)).byteLength, budgets.maxServerEntryKiB)
+}
+
+const clientJsTotal = (
+  await Promise.all(clientJs.map(async (file) => (await readFile(file)).byteLength))
+).reduce((sum, size) => sum + size, 0)
+assertBudget('Total client JavaScript', clientJsTotal, budgets.maxClientJsTotalKiB)
+
+for (const file of clientJs) {
+  if (file !== clientEntry) {
+    assertBudget(
+      `Client lazy chunk ${path.relative(clientDir, file)}`,
+      (await readFile(file)).byteLength,
+      budgets.maxClientChunkKiB,
+    )
+  }
+}
+
+for (const file of serverJs) {
+  if (file !== serverEntry) {
+    assertBudget(
+      `Server module ${path.relative(serverDir, file)}`,
+      (await readFile(file)).byteLength,
+      budgets.maxServerChunkKiB,
+    )
+  }
+}
+
+for (const file of serverJs) {
+  const source = await readFile(file, 'utf8')
+  for (const { label, pattern } of forbiddenWorkerPatterns) {
+    if (pattern.test(source)) {
+      fail(`${label} found in ${path.relative(serverDir, file)}`)
+    }
+  }
+}
+
+for (const file of clientJs) {
+  const source = await readFile(file, 'utf8')
+  for (const { label, pattern } of forbiddenClientPatterns) {
+    if (pattern.test(source)) {
+      fail(`${label} found in client asset ${path.relative(clientDir, file)}`)
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'))
+  process.exitCode = 1
+} else {
+  console.log(
+    [
+      `Checked TanStack output in ${distRoot}`,
+      `clientEntry=${formatKiB(clientEntry ? (await readFile(clientEntry)).byteLength : 0)}`,
+      `clientJsTotal=${formatKiB(clientJsTotal)}`,
+      `serverEntry=${formatKiB(existsSync(serverEntry) ? (await readFile(serverEntry)).byteLength : 0)}`,
+    ].join('\n'),
+  )
+}

--- a/specs-tanstack/scaffold.spec.ts
+++ b/specs-tanstack/scaffold.spec.ts
@@ -41,6 +41,37 @@ test('marks HEAD page responses as no-store', async ({ request }) => {
   expect(response.headers()['cache-control']).toBe('no-store')
 })
 
+test('keeps request-personalized pages uncacheable and varied by request hints', async ({
+  request,
+}) => {
+  for (const path of ['/', '/en', '/en/download']) {
+    const response = await request.get(path, {
+      headers: {
+        'Sec-CH-Prefers-Color-Scheme': 'dark',
+        'Sec-CH-UA-Arch': '"arm"',
+        'Sec-CH-UA-Bitness': '"64"',
+        'Sec-CH-UA-Mobile': '?0',
+        'Sec-CH-UA-Platform': '"macOS"',
+      },
+    })
+    const headers = response.headers()
+
+    expect(response.status()).toBe(200)
+    expect(headers['cache-control']).toBe('no-store')
+    expect(headers['accept-ch']).toContain('Sec-CH-UA-Platform')
+    expect(headers['accept-ch']).toContain('Sec-CH-Prefers-Color-Scheme')
+    for (const value of [
+      'Sec-CH-UA-Platform',
+      'Sec-CH-UA-Arch',
+      'Sec-CH-UA-Bitness',
+      'Sec-CH-UA-Mobile',
+      'Sec-CH-Prefers-Color-Scheme',
+    ]) {
+      expect(headers.vary).toContain(value)
+    }
+  }
+})
+
 test('serves static assets before SSR with cache headers', async ({
   request,
 }) => {

--- a/src/lib/route-handlers.test.ts
+++ b/src/lib/route-handlers.test.ts
@@ -85,7 +85,7 @@ describe('handleFcd', () => {
     )
 
     expect(response.status).toBe(200)
-    expect(response.body).not.toBeNull()
+    expect(response.body).toBe(body)
     await expect(response.json()).resolves.toEqual({ items: ['large'] })
   })
 


### PR DESCRIPTION
## Summary
- add a repeatable `check:tanstack-output` build-output hardening check for production Wrangler config, sourcemap cleanup, bundle budgets, and Next/OpenNext leakage
- run the output hardening check in CI after the TanStack production build exists
- strengthen request-personalized HTML cache/Vary coverage and streaming proxy tests

## Validation
- pnpm run lint:next
- pnpm run typecheck
- pnpm run test:unit
- pnpm run check:tanstack-imports
- pnpm run check:tanstack-output
- pnpm exec wrangler deploy --config dist/server/wrangler.json --dry-run
- pnpm run test:e2e:tanstack
- pnpm run test:e2e:next
- blocker review: no blockers found

Closes #491