### PR TITLE
Fix routing and i18n edge cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:tanstack": "vite build --config vite.config.ts",
     "preview:tanstack": "vite preview --config vite.config.ts --host 127.0.0.1 --port 3002",
     "test:e2e:tanstack": "node scripts/test-tanstack-e2e.mjs",
-    "start": "vite preview --config vite.config.ts --host 127.0.0.1 --port 3002",
+    "start": "vite build --config vite.config.ts && vite preview --config vite.config.ts --host 127.0.0.1 --port 3002",
     "preview": "vite build --config vite.config.ts && vite preview --config vite.config.ts --host 127.0.0.1 --port 3002",
     "deploy": "vite build --config vite.config.ts && wrangler deploy --config dist/server/wrangler.json",
     "upload": "vite build --config vite.config.ts && wrangler versions upload --config dist/server/wrangler.json",

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -203,6 +203,18 @@ test('keeps header pathname current after client history changes', async ({
   await expect(page).toHaveURL('http://127.0.0.1:3002/fr/download')
 })
 
+test('loads localized download pages with hash fragments', async ({ page }) => {
+  await page.goto('/en/download#download')
+
+  await expect(page).toHaveURL('http://127.0.0.1:3002/en/download#download')
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'Download' }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: /Download v\d+\.\d+\.\d+/ }).first(),
+  ).toHaveAttribute('href', /\/dist\/poi-setup-\d+\.\d+\.\d+\.exe/)
+})
+
 test('switches language with NEXT_LOCALE and canonical URL', async ({
   page,
 }) => {

--- a/src/components/i18n-provider.tsx
+++ b/src/components/i18n-provider.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { type Resource, createInstance } from 'i18next'
-import { type FC, type PropsWithChildren } from 'react'
+import { type FC, type PropsWithChildren, useMemo } from 'react'
 import { I18nextProvider } from 'react-i18next'
 
 import { initTranslations } from '~/i18n'
@@ -18,9 +18,11 @@ export const I18nProvider: FC<I18nProviderProps> = ({
   namespaces,
   resources,
 }) => {
-  const i18n = createInstance()
-
-  void initTranslations(locale, namespaces, i18n, resources)
+  const i18n = useMemo(() => {
+    const instance = createInstance()
+    void initTranslations(locale, namespaces, instance, resources)
+    return instance
+  }, [locale, namespaces, resources])
 
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
 }

--- a/src/components/language-chooser.tsx
+++ b/src/components/language-chooser.tsx
@@ -14,7 +14,7 @@ import {
 } from '~/components/ui/dropdown-menu'
 import { useI18nPathname } from '~/hooks/use-i18n-pathname'
 import { i18nConfig } from '~/i18n-config'
-import { localizePath } from '~/lib/i18n-routing'
+import { localizeHref } from '~/lib/i18n-routing'
 
 export const LanguageChooser = () => {
   const { t, i18n } = useTranslation()
@@ -28,10 +28,17 @@ export const LanguageChooser = () => {
       const date = new Date()
       date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000)
       const expires = date.toUTCString()
-      document.cookie = `NEXT_LOCALE=${newLocale};expires=${expires};path=/`
+      document.cookie = `NEXT_LOCALE=${newLocale};expires=${expires};path=/;SameSite=Lax`
 
       const pathname = currentPathname ?? window.location.pathname
-      window.location.assign(localizePath(pathname, newLocale))
+      window.location.assign(
+        localizeHref(
+          pathname,
+          newLocale,
+          window.location.search,
+          window.location.hash,
+        ),
+      )
     },
     [currentPathname],
   )

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -31,6 +31,7 @@ export const initTranslations = async (
     defaultNS: namespaces[0],
     fallbackNS: namespaces[0],
     ns: namespaces,
+    initAsync: !resources,
     preload: resources ? [] : i18nConfig.locales,
     // debug: process.env.NODE_ENV === 'development',
   })

--- a/src/lib/i18n-routing.test.ts
+++ b/src/lib/i18n-routing.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseCookieHeader, resolvePreferredLocale } from './i18n-routing'
+import {
+  localizeHref,
+  parseCookieHeader,
+  resolvePreferredLocale,
+} from './i18n-routing'
 
 describe('parseCookieHeader', () => {
   it('uses a null-prototype cookie map for untrusted cookie names', () => {
@@ -10,6 +14,17 @@ describe('parseCookieHeader', () => {
     expect(cookies.__proto__).toBe('polluted')
     expect(cookies.constructor).toBe('value')
     expect(Object.prototype).not.toHaveProperty('polluted')
+  })
+})
+
+describe('localizeHref', () => {
+  it('preserves search params and hash fragments while changing locale', () => {
+    expect(
+      localizeHref('/download', 'fr', '?channel=stable', '#download'),
+    ).toBe('/fr/download?channel=stable#download')
+    expect(
+      localizeHref('/en/download', 'ja', '?channel=stable', '#download'),
+    ).toBe('/download?channel=stable#download')
   })
 })
 

--- a/src/lib/i18n-routing.ts
+++ b/src/lib/i18n-routing.ts
@@ -38,6 +38,13 @@ export const localizePath = (pathname: string, locale: string) => {
   return stripped === '/' ? `/${locale}` : `/${locale}${stripped}`
 }
 
+export const localizeHref = (
+  pathname: string,
+  locale: string,
+  search = '',
+  hash = '',
+) => `${localizePath(pathname, locale)}${search}${hash}`
+
 export const parseCookieHeader = (cookieHeader: string | null) => {
   const cookies = Object.create(null) as Record<string, string>
   for (const entry of (cookieHeader ?? '').split(';')) {

--- a/src/lib/route-handlers.test.ts
+++ b/src/lib/route-handlers.test.ts
@@ -107,6 +107,18 @@ describe('handleFcd', () => {
     expect(response.status).toBe(404)
   })
 
+  it('maps upstream server errors to 502', async () => {
+    const target =
+      'https://raw.githubusercontent.com/poooi/poi/master/assets/data/fcd/meta.json'
+    const response = await handleFcd(
+      makeRequest('/fcd/meta.json'),
+      { filename: 'meta.json' },
+      { fetcher: mockFetch({ [target]: new Response('', { status: 500 }) }) },
+    )
+
+    expect(response.status).toBe(502)
+  })
+
   it('maps final proxy network failure to 504', async () => {
     const target =
       'https://raw.githubusercontent.com/poooi/poi/master/assets/data/fcd/meta.json'

--- a/src/lib/route-handlers.ts
+++ b/src/lib/route-handlers.ts
@@ -69,7 +69,7 @@ const reverseFetch = async (
   }
 
   if (!resp.ok) {
-    return notFound()
+    return mapUpstreamError(new UpstreamResponseError(resp.status))
   }
 
   const fulfilled = new Response(resp.body, resp)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -38,6 +38,8 @@ const resources = {
   'zh-Hant': { common: zhHantCommon },
 } satisfies Resource
 
+const commonNamespaces = ['common']
+
 const getCurrentRequestHeaders = createServerOnlyFn(
   () => new Headers(getRequestHeaders()),
 )
@@ -207,7 +209,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           <DesktopBackground initialEnabled={!isMobile} />
           <I18nProvider
             locale={locale}
-            namespaces={['common']}
+            namespaces={commonNamespaces}
             resources={resources}
           >
             <div className="relative z-0 mx-auto flex min-h-screen max-w-[960px] flex-col items-center justify-center px-4 md:px-8">


### PR DESCRIPTION
## Summary
- map non-404 upstream proxy failures to gateway errors instead of hiding them as 404s
- initialize client i18n synchronously from bundled resources and keep provider inputs stable
- preserve localized URL search/hash construction and harden the locale cookie with SameSite=Lax
- make `pnpm start` build before previewing so it works on a clean checkout
- add a regression for direct localized download loads with hash fragments

## Tests
- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm run test:unit`
- `corepack pnpm run build:tanstack`
- `corepack pnpm exec playwright test specs-tanstack/i18n.spec.ts -g "switches language with NEXT_LOCALE" --config=playwright.tanstack.config.ts --reporter=line`
- `corepack pnpm exec playwright test specs-tanstack/i18n.spec.ts -g "loads localized download pages with hash" --config=playwright.tanstack.config.ts --reporter=line --workers=1`
