### PR TITLE
Fix Chinese locale route matching

### DIFF
--- a/paraglide.config.js
+++ b/paraglide.config.js
@@ -2,24 +2,33 @@
 
 /** @typedef {import('@inlang/paraglide-js').CompilerOptions} CompilerOptions */
 
+const baseLocale = 'ja'
 const locales = /** @type {const} */ ([
   'en',
   'fr',
-  'ja',
+  baseLocale,
   'ko',
   'zh-Hans',
   'zh-Hant',
 ])
+const localizedLocalesBySpecificity = [
+  ...locales.filter((locale) => locale !== baseLocale),
+  baseLocale,
+]
 
 const localizedRootPaths =
   /** @type {NonNullable<CompilerOptions['urlPatterns']>[number]['localized']} */ (
-    locales.map((locale) => [locale, locale === 'ja' ? '/' : `/${locale}`])
+    localizedLocalesBySpecificity.map((locale) => [
+      locale,
+      locale === baseLocale ? '/' : `/${locale}`,
+    ])
   )
 const localizedCatchAllPaths =
   /** @type {NonNullable<CompilerOptions['urlPatterns']>[number]['localized']} */ (
-    locales.map((locale) => [
+    // The base-locale catch-all is greedy, so keep it after prefixed locales.
+    localizedLocalesBySpecificity.map((locale) => [
       locale,
-      locale === 'ja' ? '/:path(.*)?' : `/${locale}/:path(.*)?`,
+      locale === baseLocale ? '/:path(.*)?' : `/${locale}/:path(.*)?`,
     ])
   )
 

--- a/specs-tanstack/i18n.spec.ts
+++ b/specs-tanstack/i18n.spec.ts
@@ -115,6 +115,22 @@ test('serves localized download and explore pages', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'what is poi' })).toBeVisible()
 })
 
+test('serves script-cased Chinese localized download pages', async ({
+  page,
+}) => {
+  const simplifiedResponse = await page.goto('/zh-Hans/download')
+  expect(simplifiedResponse?.status()).toBe(200)
+  await expect(page.locator('html')).toHaveAttribute('lang', 'zh-Hans')
+  await expect(page.getByRole('heading', { name: '下载' })).toBeVisible()
+  await expect(page.getByRole('link', { name: '每夜构建' })).toBeVisible()
+
+  const traditionalResponse = await page.goto('/zh-Hant/download')
+  expect(traditionalResponse?.status()).toBe(200)
+  await expect(page.locator('html')).toHaveAttribute('lang', 'zh-Hant')
+  await expect(page.getByRole('heading', { name: '下載' })).toBeVisible()
+  await expect(page.getByRole('link', { name: '每夜構建' })).toBeVisible()
+})
+
 test('serves framework-neutral header navigation controls', async ({
   page,
 }) => {

--- a/src/lib/i18n-routing.test.ts
+++ b/src/lib/i18n-routing.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { deLocalizeHref } from '~/paraglide/runtime'
+
 import {
   localizeHref,
   parseCookieHeader,
@@ -25,6 +27,11 @@ describe('localizeHref', () => {
     expect(
       localizeHref('/en/download', 'ja', '?channel=stable', '#download'),
     ).toBe('/download?channel=stable#download')
+  })
+
+  it('delocalizes script-cased Chinese locale paths', () => {
+    expect(deLocalizeHref('/zh-Hans/download')).toBe('/download')
+    expect(deLocalizeHref('/zh-Hant/download')).toBe('/download')
   })
 })
 


### PR DESCRIPTION
## Summary
- reorder Paraglide URL pattern generation so prefixed locales match before the base-locale catch-all
- add unit coverage for delocalizing zh-Hans and zh-Hant paths
- add TanStack E2E coverage for zh-Hans/download and zh-Hant/download

## Tests
- corepack pnpm exec vitest run --config vitest.config.ts src/lib/i18n-routing.test.ts
- corepack pnpm run build:tanstack
- corepack pnpm exec playwright test specs-tanstack/i18n.spec.ts -g "script-cased Chinese localized download pages|serves localized download and explore pages" --config=playwright.tanstack.config.ts --reporter=line
- corepack pnpm exec eslint paraglide.config.js src/lib/i18n-routing.test.ts specs-tanstack/i18n.spec.ts --ext .js,.ts,.tsx
- corepack pnpm run typecheck