### PR TITLE
Simplify worker request routing

### DIFF
--- a/specs-tanstack/scaffold.spec.ts
+++ b/specs-tanstack/scaffold.spec.ts
@@ -198,3 +198,44 @@ test('serves invalid proxy route inputs as 404 through TanStack', async ({
     expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
   }
 })
+
+test('keeps proxy collection roots reserved before locale redirects', async ({
+  request,
+}) => {
+  for (const path of [
+    '/dist',
+    '/dist/',
+    '/fcd',
+    '/fcd/',
+    '/update',
+    '/update/',
+  ]) {
+    const response = await request.get(path, {
+      headers: {
+        Cookie: 'NEXT_LOCALE=en',
+      },
+      maxRedirects: 0,
+    })
+
+    expect(response.status()).toBe(404)
+    expect(response.headers().location).toBeUndefined()
+    expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
+  }
+})
+
+test('returns 404 for unknown localized page shapes', async ({ request }) => {
+  for (const path of [
+    '/missing',
+    '/en/missing',
+    '/xx/download',
+    '/fr/download/extra',
+  ]) {
+    const response = await request.get(path, {
+      maxRedirects: 0,
+    })
+
+    expect(response.status()).toBe(404)
+    expect(response.headers().location).toBeUndefined()
+    expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
+  }
+})

--- a/specs-tanstack/scaffold.spec.ts
+++ b/specs-tanstack/scaffold.spec.ts
@@ -199,6 +199,25 @@ test('serves invalid proxy route inputs as 404 through TanStack', async ({
   }
 })
 
+test('keeps proxy subroutes out of page locale/header handling', async ({
+  request,
+}) => {
+  const response = await request.get('/dist/en', {
+    headers: {
+      Cookie: 'NEXT_LOCALE=fr',
+    },
+    maxRedirects: 0,
+  })
+
+  expect(response.status()).toBe(404)
+  expect(response.headers().location).toBeUndefined()
+  expect(response.headers()['x-poi-codename']).toBe('Shiratsuyu')
+  expect(response.headers()['accept-ch']).toBeUndefined()
+  expect(response.headers()['critical-ch']).toBeUndefined()
+  expect(response.headers()['cache-control']).not.toBe('no-store')
+  expect(response.headers().vary).not.toContain('Sec-CH-UA-Platform')
+})
+
 test('keeps proxy collection roots reserved before locale redirects', async ({
   request,
 }) => {

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -210,4 +210,22 @@ describe('handleWorkerRequest', () => {
       mocks.startFetch.mock.calls[0]![0].headers.get('Sec-Fetch-Dest'),
     ).toBe('document')
   })
+
+  it('does not wrap proxy subroutes with Paraglide', async () => {
+    const response = await handleWorkerRequest(
+      makeRequest('/dist/en', {
+        headers: {
+          Cookie: 'NEXT_LOCALE=fr',
+          'Sec-Fetch-Dest': 'document',
+        },
+      }),
+      makeEnv(),
+      makeCtx(),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toBe('start:/dist/en')
+    expect(mocks.startFetch).toHaveBeenCalledOnce()
+    expect(mocks.paraglideMiddleware).not.toHaveBeenCalled()
+  })
 })

--- a/src/worker.test.ts
+++ b/src/worker.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  paraglideMiddleware:
+    vi.fn<
+      (
+        request: Request,
+        resolve: () => Promise<Response>,
+      ) => Response | Promise<Response>
+    >(),
+  startFetch:
+    vi.fn<
+      (
+        request: Request,
+        options: { context: { requestHeaders: [string, string][] } },
+      ) => Promise<Response>
+    >(),
+  withSentry: vi.fn<(_options: unknown, handler: unknown) => unknown>(
+    (_options, handler) => handler,
+  ),
+}))
+
+vi.mock('@sentry/cloudflare', () => ({
+  withSentry: mocks.withSentry,
+}))
+
+vi.mock('@tanstack/react-start/server-entry', () => ({
+  default: {
+    fetch: mocks.startFetch,
+  },
+}))
+
+vi.mock('~/paraglide/server', () => ({
+  paraglideMiddleware: mocks.paraglideMiddleware,
+}))
+
+import { handleWorkerRequest } from './worker'
+
+type WorkerEnvForTest = Parameters<typeof handleWorkerRequest>[1]
+type AssetsFetchForTest = NonNullable<WorkerEnvForTest['ASSETS']>['fetch']
+
+const makeRequest = (path: string, init?: RequestInit) =>
+  new Request(`https://poi.moe${path}`, init)
+
+const makeCtx = () => ({
+  waitUntil: vi.fn(),
+})
+
+const makeEnv = (fetch?: AssetsFetchForTest): WorkerEnvForTest => ({
+  ASSETS: fetch
+    ? {
+        fetch,
+      }
+    : undefined,
+})
+
+beforeEach(() => {
+  mocks.paraglideMiddleware.mockReset()
+  mocks.paraglideMiddleware.mockImplementation((_request, resolve) => resolve())
+  mocks.startFetch.mockReset()
+  mocks.startFetch.mockImplementation(async (request) => {
+    return new Response(`start:${new URL(request.url).pathname}`, {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+      },
+    })
+  })
+})
+
+describe('handleWorkerRequest', () => {
+  it.each(['/dist', '/dist/', '/fcd', '/fcd/', '/update', '/update/'])(
+    'short-circuits reserved proxy root %s before locale routing',
+    async (path) => {
+      const response = await handleWorkerRequest(
+        makeRequest(path, {
+          headers: {
+            Cookie: 'NEXT_LOCALE=en',
+          },
+        }),
+        makeEnv(),
+        makeCtx(),
+      )
+
+      expect(response.status).toBe(404)
+      expect(mocks.startFetch).not.toHaveBeenCalled()
+      expect(mocks.paraglideMiddleware).not.toHaveBeenCalled()
+    },
+  )
+
+  it('canonicalizes localized page paths before TanStack routing', async () => {
+    const response = await handleWorkerRequest(
+      makeRequest('/ja/download/'),
+      makeEnv(),
+      makeCtx(),
+    )
+
+    expect(response.status).toBe(308)
+    expect(response.headers.get('Location')).toBe('https://poi.moe/download')
+    expect(mocks.startFetch).not.toHaveBeenCalled()
+  })
+
+  it('redirects unprefixed pages to the preferred non-default locale', async () => {
+    const response = await handleWorkerRequest(
+      makeRequest('/download?from=unit', {
+        headers: {
+          'Accept-Language': 'fr',
+        },
+      }),
+      makeEnv(),
+      makeCtx(),
+    )
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('Location')).toBe(
+      'https://poi.moe/fr/download?from=unit',
+    )
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+    expect(response.headers.get('Vary')).toBe('Cookie, Accept-Language')
+    expect(mocks.startFetch).not.toHaveBeenCalled()
+  })
+
+  it.each(['/missing', '/en/missing', '/xx/download', '/fr/download/extra'])(
+    'returns 404 for unknown localized page path %s',
+    async (path) => {
+      const response = await handleWorkerRequest(
+        makeRequest(path),
+        makeEnv(),
+        makeCtx(),
+      )
+
+      expect(response.status).toBe(404)
+      expect(mocks.startFetch).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([
+    ['/robots.txt', 'public,max-age=3600'],
+    ['/assets/app.abc123.js', 'public,max-age=31536000,immutable'],
+  ])(
+    'serves asset %s before TanStack with cache headers',
+    async (path, cache) => {
+      const assetFetch = vi.fn(async () => new Response('asset'))
+      const response = await handleWorkerRequest(
+        makeRequest(path),
+        makeEnv(assetFetch),
+        makeCtx(),
+      )
+
+      expect(response.status).toBe(200)
+      await expect(response.text()).resolves.toBe('asset')
+      expect(response.headers.get('Cache-Control')).toBe(cache)
+      expect(assetFetch).toHaveBeenCalledOnce()
+      expect(mocks.startFetch).not.toHaveBeenCalled()
+    },
+  )
+
+  it('falls back to TanStack when an asset binding misses', async () => {
+    const response = await handleWorkerRequest(
+      makeRequest('/favicon.ico'),
+      makeEnv(async () => new Response('', { status: 404 })),
+      makeCtx(),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toBe('start:/favicon.ico')
+    expect(mocks.startFetch).toHaveBeenCalledOnce()
+  })
+
+  it('normalizes monitoring slash routes before calling TanStack', async () => {
+    await handleWorkerRequest(
+      makeRequest('/api/monitoring/', {
+        headers: {
+          'X-Unit-Test': 'monitoring',
+        },
+      }),
+      makeEnv(),
+      makeCtx(),
+    )
+
+    expect(mocks.startFetch).toHaveBeenCalledOnce()
+    const [request, options] = mocks.startFetch.mock.calls[0]!
+    expect(new URL(request.url).pathname).toBe('/api/monitoring')
+    expect(options.context.requestHeaders).toContainEqual([
+      'x-unit-test',
+      'monitoring',
+    ])
+    expect(mocks.paraglideMiddleware).not.toHaveBeenCalled()
+  })
+
+  it('wraps page requests with Paraglide without forwarding Sec-Fetch-Dest', async () => {
+    let middlewareRequest: Request | undefined
+    mocks.paraglideMiddleware.mockImplementation(async (request, resolve) => {
+      middlewareRequest = request
+      return await resolve()
+    })
+
+    await handleWorkerRequest(
+      makeRequest('/en', {
+        headers: {
+          'Sec-Fetch-Dest': 'document',
+        },
+      }),
+      makeEnv(),
+      makeCtx(),
+    )
+
+    expect(middlewareRequest?.headers.get('Sec-Fetch-Dest')).toBeNull()
+    expect(mocks.startFetch).toHaveBeenCalledOnce()
+    expect(
+      mocks.startFetch.mock.calls[0]![0].headers.get('Sec-Fetch-Dest'),
+    ).toBe('document')
+  })
+})

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -27,14 +27,16 @@ interface ExecutionContextLike {
   passThroughOnException?(): void
 }
 
+interface StartHandlerContext {
+  ctx: ExecutionContextLike
+  env: WorkerEnv
+  requestHeaders: [string, string][]
+}
+
 type StartHandlerWithContext = (
   request: Request,
   options: {
-    context: {
-      ctx: ExecutionContextLike
-      env: WorkerEnv
-      requestHeaders: [string, string][]
-    }
+    context: StartHandlerContext
   },
 ) => Promise<Response>
 
@@ -42,9 +44,16 @@ type SentryHandler = Parameters<typeof withSentry>[1]
 
 const clientHintValues =
   'Sec-CH-UA-Platform, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Mobile, Sec-CH-Prefers-Color-Scheme'
+const localizedPageNames = new Set(['download', 'explore'])
+const proxyRoots = new Set(['/dist', '/fcd', '/update'])
+const proxyPrefixes = ['/dist/', '/fcd/', '/update/']
 
 const buildDate = process.env.BUILD_DATE ?? 'development'
 const commitHash = process.env.COMMIT_HASH ?? 'development'
+
+const trimTrailingSlashes = (pathname: string) => {
+  return pathname === '/' ? pathname : pathname.replace(/\/+$/, '')
+}
 
 const isFileRequest = (pathname: string) => {
   return pathname.includes('.')
@@ -60,9 +69,26 @@ const isSocialImagePath = (pathname: string) => {
 }
 
 const isProxyRootPath = (pathname: string) => {
-  const normalized = pathname === '/' ? pathname : pathname.replace(/\/+$/, '')
+  return proxyRoots.has(trimTrailingSlashes(pathname))
+}
+
+const isProxyRoutePath = (pathname: string) => {
   return (
-    normalized === '/dist' || normalized === '/fcd' || normalized === '/update'
+    isProxyRootPath(pathname) ||
+    proxyPrefixes.some((prefix) => pathname.startsWith(prefix))
+  )
+}
+
+const isDocumentRequestMethod = (method: string) => {
+  return method === 'GET' || method === 'HEAD'
+}
+
+const isDocumentPath = (pathname: string) => {
+  return (
+    !pathname.startsWith('/api/') &&
+    !pathname.startsWith('/status') &&
+    !isSocialImagePath(pathname) &&
+    !isFileRequest(pathname)
   )
 }
 
@@ -77,92 +103,67 @@ const normalizeMonitoringRequest = (request: Request) => {
 
 const isPageRequest = (request: Request) => {
   const { pathname } = new URL(request.url)
+  return isDocumentRequestMethod(request.method) && isDocumentPath(pathname)
+}
+
+const shouldHandleLocaleRedirects = (request: Request, pathname: string) => {
   return (
-    (request.method === 'GET' || request.method === 'HEAD') &&
-    !pathname.startsWith('/api/') &&
-    !pathname.startsWith('/status') &&
-    !isSocialImagePath(pathname) &&
-    !isFileRequest(pathname)
+    isDocumentRequestMethod(request.method) &&
+    isDocumentPath(pathname) &&
+    !isProxyRoutePath(pathname)
   )
 }
 
-const isPagePath = (pathname: string) => {
+const isKnownLocalizedPagePath = (pathname: string) => {
+  const [firstSegment, secondSegment, ...restSegments] = pathname
+    .split('/')
+    .filter(Boolean)
+
+  if (!firstSegment) {
+    return true
+  }
+
+  if (restSegments.length > 0) {
+    return false
+  }
+
+  if (!secondSegment) {
+    return (
+      localizedPageNames.has(firstSegment) || isSupportedLocale(firstSegment)
+    )
+  }
+
   return (
-    !pathname.startsWith('/api/') &&
-    !pathname.startsWith('/status') &&
-    !isProxyRootPath(pathname) &&
-    !pathname.startsWith('/dist/') &&
-    !pathname.startsWith('/fcd/') &&
-    !pathname.startsWith('/update/') &&
-    !isSocialImagePath(pathname) &&
-    !isFileRequest(pathname)
+    localizedPageNames.has(secondSegment) && isSupportedLocale(firstSegment)
   )
 }
 
 const redirectTo = (request: Request, pathname: string, status: 307 | 308) => {
   const url = new URL(request.url)
   url.pathname = pathname
-  const headers = new Headers()
+  const headers = new Headers({
+    'Content-Type': 'text/plain; charset=utf-8',
+    Location: url.toString(),
+  })
   if (status === 307) {
     headers.set('Cache-Control', 'no-store')
     headers.set('Vary', 'Cookie, Accept-Language')
   }
-  headers.set('Content-Type', 'text/plain; charset=utf-8')
-  return new Response('', {
-    headers: {
-      ...Object.fromEntries(headers),
-      Location: url.toString(),
-    },
-    status,
-  })
+  return new Response('', { headers, status })
 }
 
 const handleLocaleRedirects = (request: Request) => {
   const { pathname } = new URL(request.url)
-  if (request.method !== 'GET' && request.method !== 'HEAD') {
+  if (!shouldHandleLocaleRedirects(request, pathname)) {
     return undefined
   }
 
-  if (!isPagePath(pathname)) {
-    return undefined
-  }
-
-  const pathSegments = pathname.split('/').filter(Boolean)
-  const firstSegment = pathSegments[0]
-  const secondSegment = pathSegments[1]
-  const knownUnprefixedPage =
-    pathSegments.length === 1 &&
-    (firstSegment === 'download' || firstSegment === 'explore')
-  const knownDefaultPage = pathSegments.length === 0 || knownUnprefixedPage
-  const localeShapedSegment =
-    !!firstSegment && /^[a-z]{2}(?:-[A-Za-z]+)?$/.test(firstSegment)
-  const supportedLocalizedPage =
-    firstSegment &&
-    isSupportedLocale(firstSegment) &&
-    (pathSegments.length === 1 ||
-      (pathSegments.length === 2 &&
-        (secondSegment === 'download' || secondSegment === 'explore')))
-  const knownLocalizedPage =
-    firstSegment &&
-    !knownUnprefixedPage &&
-    !isSupportedLocale(firstSegment) &&
-    (pathSegments.length === 1 ||
-      (localeShapedSegment &&
-        pathSegments.length === 2 &&
-        (secondSegment === 'download' || secondSegment === 'explore')))
-  if (knownLocalizedPage) {
-    return new Response('', { status: 404 })
-  }
-
-  if (!knownDefaultPage && !supportedLocalizedPage) {
+  if (!isKnownLocalizedPagePath(pathname)) {
     return new Response('', { status: 404 })
   }
 
   const locale = getPathLocale(pathname)
-  let canonicalPathname = pathname
-  if (canonicalPathname !== '/' && canonicalPathname.endsWith('/')) {
-    canonicalPathname = canonicalPathname.replace(/\/+$/, '')
-  }
+  let canonicalPathname = trimTrailingSlashes(pathname)
   if (locale && isDefaultLocale(locale)) {
     canonicalPathname = stripLocalePrefix(canonicalPathname)
   }
@@ -179,6 +180,14 @@ const handleLocaleRedirects = (request: Request) => {
   }
 
   return undefined
+}
+
+const copyResponseWithHeaders = (response: Response, headers: Headers) => {
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
 }
 
 const appendVary = (headers: Headers, value: string) => {
@@ -220,11 +229,7 @@ const withGlobalHeaders = (response: Response, request: Request) => {
     }
   }
 
-  return new Response(response.body, {
-    headers,
-    status: response.status,
-    statusText: response.statusText,
-  })
+  return copyResponseWithHeaders(response, headers)
 }
 
 const withAssetHeaders = (response: Response, request: Request) => {
@@ -235,11 +240,7 @@ const withAssetHeaders = (response: Response, request: Request) => {
   } else {
     headers.set('Cache-Control', 'public,max-age=3600')
   }
-  return new Response(response.body, {
-    headers,
-    status: response.status,
-    statusText: response.statusText,
-  })
+  return copyResponseWithHeaders(response, headers)
 }
 
 const handleAsset = async (request: Request, env: WorkerEnv) => {
@@ -255,39 +256,60 @@ const handleAsset = async (request: Request, env: WorkerEnv) => {
   return withAssetHeaders(response, request)
 }
 
+const fetchStartHandler = (request: Request, context: StartHandlerContext) => {
+  return (startHandler.fetch as StartHandlerWithContext)(request, { context })
+}
+
+const withParaglide = (
+  request: Request,
+  fetchRoute: (request: Request) => Promise<Response>,
+) => {
+  const headers = new Headers(request.headers)
+  headers.delete('Sec-Fetch-Dest')
+
+  return paraglideMiddleware(new Request(request, { headers }), () =>
+    fetchRoute(request),
+  )
+}
+
+const handleStartRequest = (request: Request, context: StartHandlerContext) => {
+  const fetchRoute = (handlerRequest: Request) =>
+    fetchStartHandler(handlerRequest, context)
+
+  if (isPageRequest(request)) {
+    return withParaglide(request, fetchRoute)
+  }
+
+  return fetchRoute(request)
+}
+
+export const handleWorkerRequest = async (
+  request: Request,
+  env: WorkerEnv,
+  ctx: ExecutionContextLike,
+) => {
+  const { pathname } = new URL(request.url)
+
+  if (isProxyRootPath(pathname)) {
+    return new Response('', { status: 404 })
+  }
+
+  const workerResponse =
+    handleLocaleRedirects(request) ?? (await handleAsset(request, env))
+  if (workerResponse) {
+    return workerResponse
+  }
+
+  return handleStartRequest(normalizeMonitoringRequest(request), {
+    env,
+    ctx,
+    requestHeaders: [...request.headers],
+  })
+}
+
 const worker = {
   async fetch(request: Request, env: WorkerEnv, ctx: ExecutionContextLike) {
-    const { pathname } = new URL(request.url)
-
-    let response: Response | undefined
-    if (isProxyRootPath(pathname)) {
-      response = new Response('', { status: 404 })
-    }
-
-    response ??= handleLocaleRedirects(request)
-    response ??= await handleAsset(request, env)
-
-    const routedRequest = normalizeMonitoringRequest(request)
-    const fetchStartHandler = (handlerRequest: Request) =>
-      (startHandler.fetch as StartHandlerWithContext)(handlerRequest, {
-        context: { env, ctx, requestHeaders: [...request.headers] },
-      })
-
-    if (!response) {
-      if (isPageRequest(routedRequest)) {
-        const middlewareHeaders = new Headers(routedRequest.headers)
-        middlewareHeaders.delete('Sec-Fetch-Dest')
-        const middlewareRequest = new Request(routedRequest, {
-          headers: middlewareHeaders,
-        })
-        response = await paraglideMiddleware(middlewareRequest, () =>
-          fetchStartHandler(routedRequest),
-        )
-      } else {
-        response = await fetchStartHandler(routedRequest)
-      }
-    }
-
+    const response = await handleWorkerRequest(request, env, ctx)
     return withGlobalHeaders(response, request)
   },
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -103,7 +103,11 @@ const normalizeMonitoringRequest = (request: Request) => {
 
 const isPageRequest = (request: Request) => {
   const { pathname } = new URL(request.url)
-  return isDocumentRequestMethod(request.method) && isDocumentPath(pathname)
+  return (
+    isDocumentRequestMethod(request.method) &&
+    isDocumentPath(pathname) &&
+    !isProxyRoutePath(pathname)
+  )
 }
 
 const shouldHandleLocaleRedirects = (request: Request, pathname: string) => {


### PR DESCRIPTION
## Summary
- simplify the worker fetch pipeline into focused routing helpers
- consolidate page/path, proxy-root, and response header handling
- add worker unit coverage and TanStack e2e regressions for reserved roots and unknown localized pages

## Validation
- corepack pnpm exec vitest run src\\worker.test.ts
- corepack pnpm exec eslint src\\worker.ts src\\worker.test.ts specs-tanstack\\scaffold.spec.ts --ext .ts
- corepack pnpm run typecheck
- corepack pnpm exec vite build --config vite.config.ts
- corepack pnpm exec playwright test scaffold.spec.ts --config=playwright.tanstack.config.ts