### PR TITLE
Simplify user agent detection

### DIFF
--- a/src/lib/target.ts
+++ b/src/lib/target.ts
@@ -121,61 +121,11 @@ const parseRawUA = (headers: Headers) => {
   return UAParser(Object.fromEntries(headers))
 }
 
+type ParsedUA = Awaited<ReturnType<typeof parseUA>>
+type RawUA = ReturnType<typeof parseRawUA>
+
 const normalizeClientHintValue = (value: string | null) =>
   value?.trim().replace(/^"|"$/g, '')
-
-const detectClientHintArchitecture = (headers: Headers) => {
-  const arch = normalizeClientHintValue(headers.get('Sec-CH-UA-Arch'))
-    ?.toLowerCase()
-    .replace('-', '_')
-  const bitness = normalizeClientHintValue(headers.get('Sec-CH-UA-Bitness'))
-
-  if (arch === 'aarch64' || arch === 'arm64') {
-    return 'arm64'
-  }
-  if (arch === 'arm') {
-    if (bitness === '64') {
-      return 'arm64'
-    }
-    if (bitness === '32') {
-      return 'arm'
-    }
-    return undefined
-  }
-  if (arch === 'x86') {
-    if (bitness === '64') {
-      return 'amd64'
-    }
-    if (bitness === '32') {
-      return 'ia32'
-    }
-    return undefined
-  }
-  if (arch === 'x86_64') {
-    return 'amd64'
-  }
-
-  return undefined
-}
-
-const detectClientHintOS = (headers: Headers) => {
-  const platform = normalizeClientHintValue(
-    headers.get('Sec-CH-UA-Platform'),
-  )?.toLowerCase()
-
-  switch (platform) {
-    case 'windows':
-      return 'Windows'
-    case 'macos':
-      return 'macOS'
-    // Keep Linux distro names from the UA when available; "Linux" from
-    // Client Hints is too generic to choose deb/rpm packages.
-    case 'linux':
-      return 'Linux'
-    default:
-      return undefined
-  }
-}
 
 const detectClientHintMobile = (headers: Headers) => {
   const mobile = normalizeClientHintValue(headers.get('Sec-CH-UA-Mobile'))
@@ -188,6 +138,34 @@ const detectClientHintMobile = (headers: Headers) => {
 
   return undefined
 }
+
+const getCorrectedArchitecture = (
+  ua: ParsedUA,
+  rawUA: RawUA,
+  headers: Headers,
+) => {
+  const clientHintArch = normalizeClientHintValue(headers.get('Sec-CH-UA-Arch'))
+    ?.toLowerCase()
+    .replace('-', '_')
+  const clientHintBitness = normalizeClientHintValue(
+    headers.get('Sec-CH-UA-Bitness'),
+  )
+
+  if (
+    clientHintArch === 'x86' &&
+    clientHintBitness === undefined &&
+    rawUA.cpu.architecture
+  ) {
+    return rawUA.cpu.architecture
+  }
+
+  return ua.cpu.architecture
+}
+
+const getCorrectedOSName = (ua: ParsedUA, rawUA: RawUA) =>
+  ua.os.name === 'Linux' && rawUA.os.name && rawUA.os.name !== 'Linux'
+    ? rawUA.os.name
+    : ua.os.name
 
 const isMobileUA = (ua: ReturnType<typeof parseRawUA>) => {
   return [
@@ -205,13 +183,9 @@ export const isMobileDevice = async (headers: Headers) => {
 }
 
 const detectTargetFromUA = (
-  ua: ReturnType<typeof parseRawUA>,
-  hints?: { architecture?: string; os?: string },
+  osName: string | undefined,
+  architecture: string | undefined,
 ): DetectionResult => {
-  const osName =
-    hints?.os === 'Linux' ? (ua.os.name ?? hints.os) : (hints?.os ?? ua.os.name)
-  const architecture = hints?.architecture ?? ua.cpu.architecture
-
   if (osName === 'Linux') {
     if (architecture === 'arm64' || architecture === 'arm') {
       return {
@@ -301,21 +275,26 @@ const detectTargetFromUA = (
 export const detectTargetFromRequest = async (
   headers: Headers,
 ): Promise<DetectionResult> => {
-  return detectTargetFromUA(parseRawUA(headers), {
-    architecture: detectClientHintArchitecture(headers),
-    os: detectClientHintOS(headers),
-  })
+  const rawUA = parseRawUA(headers)
+  const ua = await parseUA(headers)
+
+  return detectTargetFromUA(
+    getCorrectedOSName(ua, rawUA),
+    getCorrectedArchitecture(ua, rawUA, headers),
+  )
 }
 
 export const detectRequestPlatform = async (
   headers: Headers,
 ): Promise<RequestPlatformResult> => {
-  const ua = parseRawUA(headers)
+  const rawUA = parseRawUA(headers)
+  const ua = await parseUA(headers)
+
   return {
-    ...detectTargetFromUA(ua, {
-      architecture: detectClientHintArchitecture(headers),
-      os: detectClientHintOS(headers),
-    }),
+    ...detectTargetFromUA(
+      getCorrectedOSName(ua, rawUA),
+      getCorrectedArchitecture(ua, rawUA, headers),
+    ),
     isMobile: detectClientHintMobile(headers) ?? isMobileUA(ua),
   }
 }


### PR DESCRIPTION
## Summary
- use ua-parser-js Client Hints parsing as the primary detection path
- keep post-parser corrections for Linux distro package selection and ambiguous x86 hints
- remove duplicated ARM/bitness normalization logic

## Tests
- pnpm run test:unit src/lib/target.test.ts
- pnpm run typecheck