### PR TITLE
Default to Apple Silicon when macOS architecture is undetected

### DIFF
--- a/src/lib/target.test.ts
+++ b/src/lib/target.test.ts
@@ -112,15 +112,15 @@ describe('detectTargetFromRequest', () => {
       },
     },
     {
-      name: 'Safari-style macOS UA without architecture hints',
+      name: 'Safari-style macOS UA without architecture hints defaults to Apple Silicon',
       headers: headersFor(
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_7) ' +
           'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15',
       ),
       expected: {
         os: OS.macos,
-        spec: PlatformSpec.X64Setup,
-        target: Target.macos,
+        spec: PlatformSpec.ARM,
+        target: Target.macosArm,
       },
     },
     {

--- a/src/lib/target.ts
+++ b/src/lib/target.ts
@@ -231,7 +231,12 @@ const detectTargetFromUA = (
     }
   }
   if (osName === 'macOS') {
-    if (architecture === 'arm64' || architecture === 'arm') {
+    // default to Apple silicon when architecture is undetected
+    if (
+      architecture === 'arm64' ||
+      architecture === 'arm' ||
+      architecture === undefined
+    ) {
       return {
         os: OS.macos,
         spec: PlatformSpec.ARM,


### PR DESCRIPTION
## Summary
- When the OS is macOS but the CPU architecture cannot be determined, recommend the arm64 (Apple Silicon) download instead of the Intel x64 build.
- An explicitly detected Intel architecture (e.g. via `Sec-CH-UA-Arch` client hints) still gets the x64 dmg.

## Why
Safari reports "Intel Mac OS X" even on Apple Silicon machines and sends no architecture client hints, so Safari users on Apple Silicon were previously served the Intel build. Apple Silicon is the sensible default for undetected macOS architecture today.

## Testing
- Updated the "Safari-style macOS UA without architecture hints" case in `target.test.ts` to expect `macos-arm`.
- `pnpm vitest run src/lib/target.test.ts` — 11 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)